### PR TITLE
Add CI for Windows and Ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        # Don't build on macOS until this issue is fixed:
+        # https://github.com/tree-sitter/tree-sitter/issues/1246
+        # os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-latest]
       fail-fast: false
     steps:
       - name: Clone repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,13 @@ on:
     branches:
       - main
 jobs:
-  build:
+  build-and-test:
     runs-on: windows-latest
     steps:
-      - run: echo "Hello, world!"
+      - name: "Clone repo"
+        uses: actions/checkout@v2
+      - name: "Install node"
+        uses: actions/setup-node@v2
+      - name: "Build"
+        run: "npm install"
   

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,14 +8,17 @@ on:
       - main
 jobs:
   build-and-test:
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
     steps:
-      - name: "Clone repo"
+      - name: Clone repo
         uses: actions/checkout@v2
-      - name: "Install node"
+      - name: Install node
         uses: actions/setup-node@v2
-      - name: "Build"
-        run: "npm install"
-      - name: "Test"
-        run: "node_modules/.bin/tree-sitter test"
+      - name: Build
+        run: npm install
+      - name: Test
+        run: node_modules/.bin/tree-sitter test
   

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
+      fail-fast: false
     steps:
       - name: Clone repo
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,4 +16,6 @@ jobs:
         uses: actions/setup-node@v2
       - name: "Build"
         run: "npm install"
+      - name: "Test"
+        run: "node_modules/.bin/tree-sitter test"
   

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+name: Build & Test
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - run: echo "Hello, world!"
+  

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,7 @@
-bindings
-node_modules
-package-lock.json
-src
-*.exp
-*.lib
-*.obj
-build
-target
 Cargo.lock
+node_modules
+build
+package-lock.json
+target
 .vscode
 test/example/Test.tla

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ build
 package-lock.json
 target
 .vscode
+.vs
 test/example/Test.tla

--- a/binding.gyp
+++ b/binding.gyp
@@ -10,11 +10,9 @@
         "bindings/node/binding.cc",
         "src/parser.c",
         "src/scanner.cc",
-        # If your language uses an external scanner, add it here.
       ],
-      "cflags_c": [
-        "-std=c99",
-      ]
+      "cflags_c": ["-std=c99"],
+      "cflags_cc": ["-Wall -Wextra -Werror"]
     }
   ]
 }

--- a/binding.gyp
+++ b/binding.gyp
@@ -11,8 +11,7 @@
         "src/parser.c",
         "src/scanner.cc",
       ],
-      #"cflags_c": ["-std=c99"],
-      "cflags_cc": ["-std=c++11"]
+      "cflags_c": ["-std=c99"]
     }
   ]
 }

--- a/binding.gyp
+++ b/binding.gyp
@@ -11,8 +11,7 @@
         "src/parser.c",
         "src/scanner.cc",
       ],
-      "cflags_c": ["-std=c99"],
-      "cflags_cc": ["-Wall -Wextra -Werror"]
+      "cflags_c": ["-std=c99"]
     }
   ]
 }

--- a/binding.gyp
+++ b/binding.gyp
@@ -11,7 +11,7 @@
         "src/parser.c",
         "src/scanner.cc",
       ],
-      "cflags_c": ["-std=c99"],
+      #"cflags_c": ["-std=c99"],
       "cflags_cc": ["-std=c++11"]
     }
   ]

--- a/binding.gyp
+++ b/binding.gyp
@@ -11,7 +11,8 @@
         "src/parser.c",
         "src/scanner.cc",
       ],
-      "cflags_c": ["-std=c99"]
+      "cflags_c": ["-std=c99"],
+      "cflags_cc": ["-std=c++11"]
     }
   ]
 }

--- a/bindings/node/index.js
+++ b/bindings/node/index.js
@@ -1,0 +1,19 @@
+try {
+  module.exports = require("../../build/Release/tree_sitter_tlaplus_binding");
+} catch (error1) {
+  if (error1.code !== 'MODULE_NOT_FOUND') {
+    throw error1;
+  }
+  try {
+    module.exports = require("../../build/Debug/tree_sitter_tlaplus_binding");
+  } catch (error2) {
+    if (error2.code !== 'MODULE_NOT_FOUND') {
+      throw error2;
+    }
+    throw error1
+  }
+}
+
+try {
+  module.exports.nodeTypeInfo = require("../../src/node-types.json");
+} catch (_) {}

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -1,0 +1,40 @@
+fn main() {
+    let src_dir = std::path::Path::new("src");
+
+    let mut c_config = cc::Build::new();
+    c_config.include(&src_dir);
+    c_config
+        .flag_if_supported("-Wno-unused-parameter")
+        .flag_if_supported("-Wno-unused-but-set-variable")
+        .flag_if_supported("-Wno-trigraphs");
+    let parser_path = src_dir.join("parser.c");
+    c_config.file(&parser_path);
+
+    // If your language uses an external scanner written in C,
+    // then include this block of code:
+
+    /*
+    let scanner_path = src_dir.join("scanner.c");
+    c_config.file(&scanner_path);
+    println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
+    */
+
+    c_config.compile("parser");
+    println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
+
+    // If your language uses an external scanner written in C++,
+    // then include this block of code:
+
+    /*
+    let mut cpp_config = cc::Build::new();
+    cpp_config.cpp(true);
+    cpp_config.include(&src_dir);
+    cpp_config
+        .flag_if_supported("-Wno-unused-parameter")
+        .flag_if_supported("-Wno-unused-but-set-variable");
+    let scanner_path = src_dir.join("scanner.cc");
+    cpp_config.file(&scanner_path);
+    cpp_config.compile("scanner");
+    println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
+    */
+}

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -1,0 +1,52 @@
+//! This crate provides tlaplus language support for the [tree-sitter][] parsing library.
+//!
+//! Typically, you will use the [language][language func] function to add this language to a
+//! tree-sitter [Parser][], and then use the parser to parse some code:
+//!
+//! ```
+//! let code = "";
+//! let mut parser = tree_sitter::Parser::new();
+//! parser.set_language(tree_sitter_tlaplus::language()).expect("Error loading tlaplus grammar");
+//! let tree = parser.parse(code, None).unwrap();
+//! ```
+//!
+//! [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
+//! [language func]: fn.language.html
+//! [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
+//! [tree-sitter]: https://tree-sitter.github.io/
+
+use tree_sitter::Language;
+
+extern "C" {
+    fn tree_sitter_tlaplus() -> Language;
+}
+
+/// Get the tree-sitter [Language][] for this grammar.
+///
+/// [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
+pub fn language() -> Language {
+    unsafe { tree_sitter_tlaplus() }
+}
+
+/// The content of the [`node-types.json`][] file for this grammar.
+///
+/// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types
+pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
+
+// Uncomment these to include any queries that this grammar contains
+
+// pub const HIGHLIGHTS_QUERY: &'static str = include_str!("../../queries/highlights.scm");
+// pub const INJECTIONS_QUERY: &'static str = include_str!("../../queries/injections.scm");
+// pub const LOCALS_QUERY: &'static str = include_str!("../../queries/locals.scm");
+// pub const TAGS_QUERY: &'static str = include_str!("../../queries/tags.scm");
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_can_load_grammar() {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(super::language())
+            .expect("Error loading tlaplus language");
+    }
+}

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1,0 +1,6651 @@
+{
+  "name": "tlaplus",
+  "rules": {
+    "source_file": {
+      "type": "SYMBOL",
+      "name": "module"
+    },
+    "single_line_comment": {
+      "type": "PATTERN",
+      "value": "\\\\\\*.*"
+    },
+    "multi_line_comment": {
+      "type": "PATTERN",
+      "value": "\\(\\*[^*]*\\*+([^)*][^*]*\\*+)*\\)"
+    },
+    "module": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_single_line"
+        },
+        {
+          "type": "STRING",
+          "value": "MODULE"
+        },
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_single_line"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "extends"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "unit"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_double_line"
+        }
+      ]
+    },
+    "_single_line": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "----"
+        },
+        {
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "REPEAT",
+            "content": {
+              "type": "IMMEDIATE_TOKEN",
+              "content": {
+                "type": "STRING",
+                "value": "-"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "_double_line": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "===="
+        },
+        {
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "REPEAT",
+            "content": {
+              "type": "IMMEDIATE_TOKEN",
+              "content": {
+                "type": "STRING",
+                "value": "="
+              }
+            }
+          }
+        }
+      ]
+    },
+    "def_eq": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "=="
+        },
+        {
+          "type": "STRING",
+          "value": "≜"
+        }
+      ]
+    },
+    "set_in": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\in"
+        },
+        {
+          "type": "STRING",
+          "value": "∈"
+        }
+      ]
+    },
+    "gets": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "<-"
+        },
+        {
+          "type": "STRING",
+          "value": "⟵"
+        }
+      ]
+    },
+    "forall": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\A"
+        },
+        {
+          "type": "STRING",
+          "value": "\\forall"
+        },
+        {
+          "type": "STRING",
+          "value": "∀"
+        }
+      ]
+    },
+    "exists": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\E"
+        },
+        {
+          "type": "STRING",
+          "value": "\\exists"
+        },
+        {
+          "type": "STRING",
+          "value": "∃"
+        }
+      ]
+    },
+    "temporal_forall": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\AA"
+        }
+      ]
+    },
+    "temporal_exists": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\EE"
+        }
+      ]
+    },
+    "all_map_to": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "|->"
+        },
+        {
+          "type": "STRING",
+          "value": "⟼"
+        }
+      ]
+    },
+    "maps_to": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "->"
+        },
+        {
+          "type": "STRING",
+          "value": "⟶"
+        }
+      ]
+    },
+    "langle_bracket": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "<<"
+        },
+        {
+          "type": "STRING",
+          "value": "〈"
+        }
+      ]
+    },
+    "rangle_bracket": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": ">>"
+        },
+        {
+          "type": "STRING",
+          "value": "〉"
+        }
+      ]
+    },
+    "case_box": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "[]"
+        },
+        {
+          "type": "STRING",
+          "value": "□"
+        }
+      ]
+    },
+    "case_arrow": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "->"
+        },
+        {
+          "type": "STRING",
+          "value": "⟶"
+        }
+      ]
+    },
+    "bullet_conj": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "/\\"
+        },
+        {
+          "type": "STRING",
+          "value": "∧"
+        }
+      ]
+    },
+    "bullet_disj": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\/"
+        },
+        {
+          "type": "STRING",
+          "value": "∨"
+        }
+      ]
+    },
+    "colon": {
+      "type": "STRING",
+      "value": ":"
+    },
+    "address": {
+      "type": "STRING",
+      "value": "@"
+    },
+    "label_as": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "::"
+        },
+        {
+          "type": "STRING",
+          "value": "∷"
+        }
+      ]
+    },
+    "placeholder": {
+      "type": "STRING",
+      "value": "_"
+    },
+    "keyword": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "ASSUME"
+        },
+        {
+          "type": "STRING",
+          "value": "ELSE"
+        },
+        {
+          "type": "STRING",
+          "value": "LOCAL"
+        },
+        {
+          "type": "STRING",
+          "value": "UNION"
+        },
+        {
+          "type": "STRING",
+          "value": "ASSUMPTION"
+        },
+        {
+          "type": "STRING",
+          "value": "ENABLED"
+        },
+        {
+          "type": "STRING",
+          "value": "MODULE"
+        },
+        {
+          "type": "STRING",
+          "value": "VARIABLE"
+        },
+        {
+          "type": "STRING",
+          "value": "AXIOM"
+        },
+        {
+          "type": "STRING",
+          "value": "EXCEPT"
+        },
+        {
+          "type": "STRING",
+          "value": "OTHER"
+        },
+        {
+          "type": "STRING",
+          "value": "VARIABLES"
+        },
+        {
+          "type": "STRING",
+          "value": "CASE"
+        },
+        {
+          "type": "STRING",
+          "value": "EXTENDS"
+        },
+        {
+          "type": "STRING",
+          "value": "SF_"
+        },
+        {
+          "type": "STRING",
+          "value": "WF_"
+        },
+        {
+          "type": "STRING",
+          "value": "CHOOSE"
+        },
+        {
+          "type": "STRING",
+          "value": "IF"
+        },
+        {
+          "type": "STRING",
+          "value": "SUBSET"
+        },
+        {
+          "type": "STRING",
+          "value": "WITH"
+        },
+        {
+          "type": "STRING",
+          "value": "CONSTANT"
+        },
+        {
+          "type": "STRING",
+          "value": "IN"
+        },
+        {
+          "type": "STRING",
+          "value": "THEN"
+        },
+        {
+          "type": "STRING",
+          "value": "CONSTANTS"
+        },
+        {
+          "type": "STRING",
+          "value": "INSTANCE"
+        },
+        {
+          "type": "STRING",
+          "value": "THEOREM"
+        },
+        {
+          "type": "STRING",
+          "value": "COROLLARY"
+        },
+        {
+          "type": "STRING",
+          "value": "DOMAIN"
+        },
+        {
+          "type": "STRING",
+          "value": "LET"
+        },
+        {
+          "type": "STRING",
+          "value": "UNCHANGED"
+        },
+        {
+          "type": "STRING",
+          "value": "BY"
+        },
+        {
+          "type": "STRING",
+          "value": "HAVE"
+        },
+        {
+          "type": "STRING",
+          "value": "QED"
+        },
+        {
+          "type": "STRING",
+          "value": "TAKE"
+        },
+        {
+          "type": "STRING",
+          "value": "DEF"
+        },
+        {
+          "type": "STRING",
+          "value": "HIDE"
+        },
+        {
+          "type": "STRING",
+          "value": "RECURSIVE"
+        },
+        {
+          "type": "STRING",
+          "value": "USE"
+        },
+        {
+          "type": "STRING",
+          "value": "DEFINE"
+        },
+        {
+          "type": "STRING",
+          "value": "PROOF"
+        },
+        {
+          "type": "STRING",
+          "value": "WITNESS"
+        },
+        {
+          "type": "STRING",
+          "value": "PICK"
+        },
+        {
+          "type": "STRING",
+          "value": "DEFS"
+        },
+        {
+          "type": "STRING",
+          "value": "PROVE"
+        },
+        {
+          "type": "STRING",
+          "value": "SUFFICES"
+        },
+        {
+          "type": "STRING",
+          "value": "NEW"
+        },
+        {
+          "type": "STRING",
+          "value": "LAMBDA"
+        },
+        {
+          "type": "STRING",
+          "value": "STATE"
+        },
+        {
+          "type": "STRING",
+          "value": "ACTION"
+        },
+        {
+          "type": "STRING",
+          "value": "TEMPORAL"
+        },
+        {
+          "type": "STRING",
+          "value": "OBVIOUS"
+        },
+        {
+          "type": "STRING",
+          "value": "OMITTED"
+        },
+        {
+          "type": "STRING",
+          "value": "LEMMA"
+        },
+        {
+          "type": "STRING",
+          "value": "PROPOSITION"
+        },
+        {
+          "type": "STRING",
+          "value": "ONLY"
+        }
+      ]
+    },
+    "identifier": {
+      "type": "PATTERN",
+      "value": "\\w*[A-Za-z]\\w*"
+    },
+    "extends": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "EXTENDS"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "identifier"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "unit": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "variable_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "constant_declaration"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "recursive_operator_declaration"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "LOCAL"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "SYMBOL",
+              "name": "operator_definition"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "LOCAL"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "SYMBOL",
+              "name": "function_definition"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "LOCAL"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "SYMBOL",
+              "name": "instance"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "LOCAL"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "SYMBOL",
+              "name": "module_definition"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "assumption"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "theorem"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "module"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_single_line"
+        }
+      ]
+    },
+    "variable_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "VARIABLE"
+            },
+            {
+              "type": "STRING",
+              "value": "VARIABLES"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "identifier"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "constant_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "CONSTANT"
+            },
+            {
+              "type": "STRING",
+              "value": "CONSTANTS"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "operator_declaration"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "operator_declaration"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "recursive_operator_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "RECURSIVE"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "operator_declaration"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "operator_declaration"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "operator_declaration": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "("
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "placeholder"
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": ","
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "placeholder"
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "STRING",
+                      "value": ")"
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "standalone_prefix_op_symbol"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "placeholder"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "placeholder"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "infix_op_symbol"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "placeholder"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "placeholder"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "postfix_op_symbol"
+            }
+          ]
+        }
+      ]
+    },
+    "operator_definition": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": "("
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "SYMBOL",
+                              "name": "operator_declaration"
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": ","
+                                  },
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "operator_declaration"
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "STRING",
+                          "value": ")"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "standalone_prefix_op_symbol"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                }
+              ]
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "infix_op_symbol"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                }
+              ]
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "postfix_op_symbol"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "def_eq"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expr"
+        }
+      ]
+    },
+    "function_definition": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "quantifier_bound"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "quantifier_bound"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "]"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "def_eq"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expr"
+        }
+      ]
+    },
+    "quantifier_bound": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "identifier"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "SYMBOL",
+              "name": "tuple_of_identifiers"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "set_in"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expr"
+        }
+      ]
+    },
+    "single_quantifier_bound": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "tuple_of_identifiers"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "set_in"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expr"
+        }
+      ]
+    },
+    "tuple_of_identifiers": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "langle_bracket"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "identifier"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "rangle_bracket"
+        }
+      ]
+    },
+    "instance": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "INSTANCE"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "WITH"
+                },
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "substitution"
+                    },
+                    {
+                      "type": "REPEAT",
+                      "content": {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": ","
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "substitution"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "substitution": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "standalone_prefix_op_symbol"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "infix_op_symbol"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "postfix_op_symbol"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "gets"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "op_or_expr"
+        }
+      ]
+    },
+    "op_or_expr": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "standalone_prefix_op_symbol"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "infix_op_symbol"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "postfix_op_symbol"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "lambda"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expr"
+        }
+      ]
+    },
+    "subexpr_prefix": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "subexpr_component"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "proof_step_id"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "!"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "subexpr_component"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "subexpr_tree_nav"
+                  }
+                ]
+              },
+              {
+                "type": "STRING",
+                "value": "!"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "subexpr_component": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "bound_op"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "bound_nonfix_op"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "standalone_prefix_op_symbol"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "infix_op_symbol"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "postfix_op_symbol"
+        }
+      ]
+    },
+    "bound_op": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "parameters",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "("
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "op_or_expr"
+                  },
+                  {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": ","
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "op_or_expr"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              {
+                "type": "STRING",
+                "value": ")"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "bound_nonfix_op": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "standalone_prefix_op_symbol"
+            },
+            {
+              "type": "STRING",
+              "value": "("
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_expr"
+            },
+            {
+              "type": "STRING",
+              "value": ")"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "infix_op_symbol"
+            },
+            {
+              "type": "STRING",
+              "value": "("
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_expr"
+            },
+            {
+              "type": "STRING",
+              "value": ","
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_expr"
+            },
+            {
+              "type": "STRING",
+              "value": ")"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "postfix_op_symbol"
+            },
+            {
+              "type": "STRING",
+              "value": "("
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_expr"
+            },
+            {
+              "type": "STRING",
+              "value": ")"
+            }
+          ]
+        }
+      ]
+    },
+    "subexpr_tree_nav": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "langle_bracket"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "rangle_bracket"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "nat_number"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "colon"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "address"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "operator_args"
+        }
+      ]
+    },
+    "operator_args": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "op_or_expr"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "op_or_expr"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "lambda": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "LAMBDA"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "identifier"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expr"
+        }
+      ]
+    },
+    "module_definition": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "("
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "operator_declaration"
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": ","
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "operator_declaration"
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "STRING",
+                      "value": ")"
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "def_eq"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "instance"
+        }
+      ]
+    },
+    "_expr": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "number"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "string"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "boolean"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "primitive_value_set"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "parentheses"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "label"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "subexpression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "proof_step_id"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "bound_op"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "bound_nonfix_op"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "prefixed_op"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "bound_prefix_op"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "bound_infix_op"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "bound_postfix_op"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "bounded_quantification"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "unbounded_quantification"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "choose"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "finite_set_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "set_filter"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "set_map"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "function_evaluation"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "function_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "set_of_functions"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "record_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "set_of_records"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "record_value"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "except"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "prev_func_val"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "tuple_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "step_expr_or_stutter"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "step_expr_no_stutter"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "fairness"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "if_then_else"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "case"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "let_in"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "conj_list"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "disj_list"
+        }
+      ]
+    },
+    "_subscript_expr": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "bound_op"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "bound_nonfix_op"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "prefixed_op"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "parentheses"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "finite_set_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "set_filter"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "set_map"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "function_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "set_of_functions"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "record_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "set_of_records"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "except"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "tuple_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "step_expr_or_stutter"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "step_expr_no_stutter"
+        }
+      ]
+    },
+    "prefixed_op": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "prefix",
+          "content": {
+            "type": "SYMBOL",
+            "name": "subexpr_prefix"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "op",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "identifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "bound_op"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "bound_nonfix_op"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "number": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "nat_number"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "real_number"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "binary_number"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "octal_number"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "hex_number"
+        }
+      ]
+    },
+    "nat_number": {
+      "type": "PATTERN",
+      "value": "\\d+"
+    },
+    "real_number": {
+      "type": "PATTERN",
+      "value": "\\d+\\.\\d+"
+    },
+    "binary_number": {
+      "type": "PATTERN",
+      "value": "(\\\\b|\\\\B)[0-1]+"
+    },
+    "octal_number": {
+      "type": "PATTERN",
+      "value": "(\\\\o|\\\\O)[0-7]+"
+    },
+    "hex_number": {
+      "type": "PATTERN",
+      "value": "(\\\\h|\\\\H)[0-9a-fA-F]+"
+    },
+    "string": {
+      "type": "PATTERN",
+      "value": "\\\".*\\\""
+    },
+    "boolean": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "TRUE"
+        },
+        {
+          "type": "STRING",
+          "value": "FALSE"
+        }
+      ]
+    },
+    "primitive_value_set": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "STRING"
+        },
+        {
+          "type": "STRING",
+          "value": "BOOLEAN"
+        },
+        {
+          "type": "STRING",
+          "value": "Nat"
+        },
+        {
+          "type": "STRING",
+          "value": "Int"
+        },
+        {
+          "type": "STRING",
+          "value": "Real"
+        }
+      ]
+    },
+    "label": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "("
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "identifier"
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": ","
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "identifier"
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "STRING",
+                      "value": ")"
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "label_as"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expr"
+        }
+      ]
+    },
+    "subexpression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "subexpr_prefix"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "subexpr_tree_nav"
+        }
+      ]
+    },
+    "parentheses": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expr"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "bounded_quantification": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "quantifier",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "forall"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "exists"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "bound",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "quantifier_bound"
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "quantifier_bound"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "FIELD",
+          "name": "expression",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_expr"
+          }
+        }
+      ]
+    },
+    "unbounded_quantification": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "quantifier",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "forall"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "exists"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "temporal_forall"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "temporal_exists"
+              }
+            ]
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "identifier",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "identifier"
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "identifier"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "FIELD",
+          "name": "expression",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_expr"
+          }
+        }
+      ]
+    },
+    "choose": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "CHOOSE"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "tuple_of_identifiers"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "set_in"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_expr"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expr"
+        }
+      ]
+    },
+    "finite_set_literal": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_expr"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "_expr"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "set_filter": {
+      "type": "PREC_DYNAMIC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "{"
+          },
+          {
+            "type": "FIELD",
+            "name": "generator",
+            "content": {
+              "type": "SYMBOL",
+              "name": "single_quantifier_bound"
+            }
+          },
+          {
+            "type": "STRING",
+            "value": ":"
+          },
+          {
+            "type": "FIELD",
+            "name": "filter",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_expr"
+            }
+          },
+          {
+            "type": "STRING",
+            "value": "}"
+          }
+        ]
+      }
+    },
+    "set_map": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "FIELD",
+          "name": "map",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_expr"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "FIELD",
+          "name": "generator",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "quantifier_bound"
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "quantifier_bound"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "function_evaluation": {
+      "type": "PREC",
+      "value": 16,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_expr"
+          },
+          {
+            "type": "STRING",
+            "value": "["
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_expr"
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_expr"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "type": "STRING",
+            "value": "]"
+          }
+        ]
+      }
+    },
+    "function_literal": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "quantifier_bound"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "quantifier_bound"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "all_map_to"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expr"
+        },
+        {
+          "type": "STRING",
+          "value": "]"
+        }
+      ]
+    },
+    "set_of_functions": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expr"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "maps_to"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expr"
+        },
+        {
+          "type": "STRING",
+          "value": "]"
+        }
+      ]
+    },
+    "record_literal": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "all_map_to"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_expr"
+                }
+              ]
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "identifier"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "all_map_to"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "_expr"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "]"
+        }
+      ]
+    },
+    "set_of_records": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                },
+                {
+                  "type": "STRING",
+                  "value": ":"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_expr"
+                }
+              ]
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "identifier"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": ":"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "_expr"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "]"
+        }
+      ]
+    },
+    "record_value": {
+      "type": "PREC_LEFT",
+      "value": 17,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_expr"
+          },
+          {
+            "type": "STRING",
+            "value": "."
+          },
+          {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        ]
+      }
+    },
+    "except": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expr"
+        },
+        {
+          "type": "STRING",
+          "value": "EXCEPT"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "!"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_except_val"
+                },
+                {
+                  "type": "STRING",
+                  "value": "="
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_expr"
+                }
+              ]
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "!"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "_except_val"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "="
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "_expr"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "]"
+        }
+      ]
+    },
+    "_except_val": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "."
+              },
+              {
+                "type": "SYMBOL",
+                "name": "identifier"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "["
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_expr"
+                  },
+                  {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": ","
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "_expr"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              {
+                "type": "STRING",
+                "value": "]"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "prev_func_val": {
+      "type": "STRING",
+      "value": "@"
+    },
+    "tuple_literal": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "langle_bracket"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_expr"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "_expr"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "rangle_bracket"
+        }
+      ]
+    },
+    "step_expr_or_stutter": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expr"
+        },
+        {
+          "type": "STRING",
+          "value": "]_"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_subscript_expr"
+        }
+      ]
+    },
+    "step_expr_no_stutter": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "langle_bracket"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expr"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "rangle_bracket"
+        },
+        {
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "STRING",
+            "value": "_"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_subscript_expr"
+        }
+      ]
+    },
+    "fairness": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "WF_"
+            },
+            {
+              "type": "STRING",
+              "value": "SF_"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_subscript_expr"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expr"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "if_then_else": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "IF"
+        },
+        {
+          "type": "FIELD",
+          "name": "if",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_expr"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "THEN"
+        },
+        {
+          "type": "FIELD",
+          "name": "then",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_expr"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "ELSE"
+        },
+        {
+          "type": "FIELD",
+          "name": "else",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_expr"
+          }
+        }
+      ]
+    },
+    "case": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "CASE"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "case_arm"
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "case_box"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "case_arm"
+                }
+              ]
+            }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "case_box"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "other_arm"
+                  }
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "case_arm": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_expr"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "case_arrow"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expr"
+        }
+      ]
+    },
+    "other_arm": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "OTHER"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "case_arrow"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expr"
+        }
+      ]
+    },
+    "let_in": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "LET"
+        },
+        {
+          "type": "REPEAT1",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "operator_definition"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "function_definition"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "module_definition"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "recursive_operator_declaration"
+              }
+            ]
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "IN"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expr"
+        }
+      ]
+    },
+    "conj_list": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_indent"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "conj_item"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_newline"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "conj_item"
+              }
+            ]
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_dedent"
+        }
+      ]
+    },
+    "conj_item": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "bullet_conj"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expr"
+        }
+      ]
+    },
+    "disj_list": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_indent"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "disj_item"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_newline"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "disj_item"
+              }
+            ]
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_dedent"
+        }
+      ]
+    },
+    "disj_item": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "bullet_disj"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expr"
+        }
+      ]
+    },
+    "lnot": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\lnot"
+        },
+        {
+          "type": "STRING",
+          "value": "\\neg"
+        },
+        {
+          "type": "STRING",
+          "value": "~"
+        },
+        {
+          "type": "STRING",
+          "value": "¬"
+        }
+      ]
+    },
+    "union": {
+      "type": "STRING",
+      "value": "UNION"
+    },
+    "powerset": {
+      "type": "STRING",
+      "value": "SUBSET"
+    },
+    "domain": {
+      "type": "STRING",
+      "value": "DOMAIN"
+    },
+    "negative": {
+      "type": "STRING",
+      "value": "-"
+    },
+    "enabled": {
+      "type": "STRING",
+      "value": "ENABLED"
+    },
+    "unchanged": {
+      "type": "STRING",
+      "value": "UNCHANGED"
+    },
+    "always": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "[]"
+        },
+        {
+          "type": "STRING",
+          "value": "□"
+        }
+      ]
+    },
+    "eventually": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "<>"
+        },
+        {
+          "type": "STRING",
+          "value": "⋄"
+        }
+      ]
+    },
+    "_prefix_op_symbol_except_negative": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "lnot"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "union"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "powerset"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "domain"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "enabled"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "unchanged"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "always"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "eventually"
+        }
+      ]
+    },
+    "standalone_prefix_op_symbol": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_prefix_op_symbol_except_negative"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "negative"
+            },
+            {
+              "type": "IMMEDIATE_TOKEN",
+              "content": {
+                "type": "STRING",
+                "value": "."
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "bound_prefix_op": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "PREC_LEFT",
+          "value": 4,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "symbol",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "lnot"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "rhs",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expr"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 8,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "symbol",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "union"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "powerset"
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "rhs",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expr"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 9,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "symbol",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "domain"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "rhs",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expr"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 12,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "symbol",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "negative"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "rhs",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expr"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 15,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "symbol",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "enabled"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "unchanged"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "always"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "eventually"
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "rhs",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expr"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "implies": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "=>"
+        },
+        {
+          "type": "STRING",
+          "value": "⟹"
+        }
+      ]
+    },
+    "plus_arrow": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "-+->"
+        },
+        {
+          "type": "STRING",
+          "value": "⇸"
+        }
+      ]
+    },
+    "equiv": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\equiv"
+        },
+        {
+          "type": "STRING",
+          "value": "≡"
+        }
+      ]
+    },
+    "iff": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "<=>"
+        },
+        {
+          "type": "STRING",
+          "value": "⟺"
+        }
+      ]
+    },
+    "leads_to": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "~>"
+        },
+        {
+          "type": "STRING",
+          "value": "⇝"
+        }
+      ]
+    },
+    "land": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "/\\"
+        },
+        {
+          "type": "STRING",
+          "value": "\\land"
+        },
+        {
+          "type": "STRING",
+          "value": "∧"
+        }
+      ]
+    },
+    "lor": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\/"
+        },
+        {
+          "type": "STRING",
+          "value": "\\lor"
+        },
+        {
+          "type": "STRING",
+          "value": "∨"
+        }
+      ]
+    },
+    "assign": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": ":="
+        },
+        {
+          "type": "STRING",
+          "value": "≔"
+        }
+      ]
+    },
+    "bnf_rule": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "::="
+        },
+        {
+          "type": "STRING",
+          "value": "⩴"
+        }
+      ]
+    },
+    "eq": {
+      "type": "STRING",
+      "value": "="
+    },
+    "neq": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "/="
+        },
+        {
+          "type": "STRING",
+          "value": "#"
+        },
+        {
+          "type": "STRING",
+          "value": "≠"
+        }
+      ]
+    },
+    "lt": {
+      "type": "STRING",
+      "value": "<"
+    },
+    "gt": {
+      "type": "STRING",
+      "value": ">"
+    },
+    "leq": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "<="
+        },
+        {
+          "type": "STRING",
+          "value": "\\leq"
+        },
+        {
+          "type": "STRING",
+          "value": "≤"
+        }
+      ]
+    },
+    "geq": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": ">="
+        },
+        {
+          "type": "STRING",
+          "value": "\\geq"
+        },
+        {
+          "type": "STRING",
+          "value": "≥"
+        }
+      ]
+    },
+    "approx": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\approx"
+        },
+        {
+          "type": "STRING",
+          "value": "≈"
+        }
+      ]
+    },
+    "rs_ttile": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "|-"
+        },
+        {
+          "type": "STRING",
+          "value": "⊢"
+        }
+      ]
+    },
+    "rd_ttile": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "|="
+        },
+        {
+          "type": "STRING",
+          "value": "⊨"
+        }
+      ]
+    },
+    "ls_ttile": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "-|"
+        },
+        {
+          "type": "STRING",
+          "value": "⊣"
+        }
+      ]
+    },
+    "ld_ttile": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "=|"
+        },
+        {
+          "type": "STRING",
+          "value": "⫤"
+        }
+      ]
+    },
+    "asymp": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\asymp"
+        },
+        {
+          "type": "STRING",
+          "value": "≍"
+        }
+      ]
+    },
+    "cong": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\cong"
+        },
+        {
+          "type": "STRING",
+          "value": "≅"
+        }
+      ]
+    },
+    "doteq": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\doteq"
+        },
+        {
+          "type": "STRING",
+          "value": "≐"
+        }
+      ]
+    },
+    "gg": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\gg"
+        },
+        {
+          "type": "STRING",
+          "value": "≫"
+        }
+      ]
+    },
+    "ll": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\ll"
+        },
+        {
+          "type": "STRING",
+          "value": "≪"
+        }
+      ]
+    },
+    "in": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\in"
+        },
+        {
+          "type": "STRING",
+          "value": "∈"
+        }
+      ]
+    },
+    "notin": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\notin"
+        },
+        {
+          "type": "STRING",
+          "value": "∉"
+        }
+      ]
+    },
+    "prec": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\prec"
+        },
+        {
+          "type": "STRING",
+          "value": "≺"
+        }
+      ]
+    },
+    "succ": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\succ"
+        },
+        {
+          "type": "STRING",
+          "value": "≻"
+        }
+      ]
+    },
+    "preceq": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\preceq"
+        },
+        {
+          "type": "STRING",
+          "value": "⪯"
+        }
+      ]
+    },
+    "succeq": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\succeq"
+        },
+        {
+          "type": "STRING",
+          "value": "⪰"
+        }
+      ]
+    },
+    "propto": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\propto"
+        },
+        {
+          "type": "STRING",
+          "value": "∝"
+        }
+      ]
+    },
+    "sim": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\sim"
+        },
+        {
+          "type": "STRING",
+          "value": "∼"
+        }
+      ]
+    },
+    "simeq": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\simeq"
+        },
+        {
+          "type": "STRING",
+          "value": "≃"
+        }
+      ]
+    },
+    "sqsubset": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\sqsubset"
+        },
+        {
+          "type": "STRING",
+          "value": "⊏"
+        }
+      ]
+    },
+    "sqsupset": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\sqsupset"
+        },
+        {
+          "type": "STRING",
+          "value": "⊐"
+        }
+      ]
+    },
+    "sqsubseteq": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\sqsubseteq"
+        },
+        {
+          "type": "STRING",
+          "value": "⊑"
+        }
+      ]
+    },
+    "sqsupseteq": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\sqsupseteq"
+        },
+        {
+          "type": "STRING",
+          "value": "⊒"
+        }
+      ]
+    },
+    "subset": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\subset"
+        },
+        {
+          "type": "STRING",
+          "value": "⊂"
+        }
+      ]
+    },
+    "supset": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\supset"
+        },
+        {
+          "type": "STRING",
+          "value": "⊃"
+        }
+      ]
+    },
+    "subseteq": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\subseteq"
+        },
+        {
+          "type": "STRING",
+          "value": "⊆"
+        }
+      ]
+    },
+    "supseteq": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\supseteq"
+        },
+        {
+          "type": "STRING",
+          "value": "⊇"
+        }
+      ]
+    },
+    "compose": {
+      "type": "STRING",
+      "value": "@@"
+    },
+    "map_to": {
+      "type": "STRING",
+      "value": ":>"
+    },
+    "map_from": {
+      "type": "STRING",
+      "value": "<:"
+    },
+    "setminus": {
+      "type": "STRING",
+      "value": "\\"
+    },
+    "cap": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\cap"
+        },
+        {
+          "type": "STRING",
+          "value": "∩"
+        }
+      ]
+    },
+    "cup": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\cup"
+        },
+        {
+          "type": "STRING",
+          "value": "∪"
+        }
+      ]
+    },
+    "dots_2": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": ".."
+        },
+        {
+          "type": "STRING",
+          "value": "‥"
+        }
+      ]
+    },
+    "dots_3": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "..."
+        },
+        {
+          "type": "STRING",
+          "value": "…"
+        }
+      ]
+    },
+    "plus": {
+      "type": "STRING",
+      "value": "+"
+    },
+    "plusplus": {
+      "type": "STRING",
+      "value": "++"
+    },
+    "oplus": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\oplus"
+        },
+        {
+          "type": "STRING",
+          "value": "(+)"
+        },
+        {
+          "type": "STRING",
+          "value": "⊕"
+        }
+      ]
+    },
+    "ominus": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\ominus"
+        },
+        {
+          "type": "STRING",
+          "value": "(-)"
+        },
+        {
+          "type": "STRING",
+          "value": "⊖"
+        }
+      ]
+    },
+    "mod": {
+      "type": "STRING",
+      "value": "%"
+    },
+    "modmod": {
+      "type": "STRING",
+      "value": "%%"
+    },
+    "vert": {
+      "type": "STRING",
+      "value": "|"
+    },
+    "vertvert": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "||"
+        },
+        {
+          "type": "STRING",
+          "value": "‖"
+        }
+      ]
+    },
+    "minus": {
+      "type": "STRING",
+      "value": "-"
+    },
+    "minusminus": {
+      "type": "STRING",
+      "value": "--"
+    },
+    "amp": {
+      "type": "STRING",
+      "value": "&"
+    },
+    "ampamp": {
+      "type": "STRING",
+      "value": "&&"
+    },
+    "odot": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\odot"
+        },
+        {
+          "type": "STRING",
+          "value": "(.)"
+        },
+        {
+          "type": "STRING",
+          "value": "⊙"
+        }
+      ]
+    },
+    "oslash": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\oslash"
+        },
+        {
+          "type": "STRING",
+          "value": "(/)"
+        },
+        {
+          "type": "STRING",
+          "value": "⊘"
+        }
+      ]
+    },
+    "otimes": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\otimes"
+        },
+        {
+          "type": "STRING",
+          "value": "(\\X)"
+        },
+        {
+          "type": "STRING",
+          "value": "⊗"
+        }
+      ]
+    },
+    "mul": {
+      "type": "STRING",
+      "value": "*"
+    },
+    "mulmul": {
+      "type": "STRING",
+      "value": "**"
+    },
+    "slash": {
+      "type": "STRING",
+      "value": "/"
+    },
+    "slashslash": {
+      "type": "STRING",
+      "value": "//"
+    },
+    "bigcirc": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\bigcirc"
+        },
+        {
+          "type": "STRING",
+          "value": "◯"
+        }
+      ]
+    },
+    "bullet": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\bullet"
+        },
+        {
+          "type": "STRING",
+          "value": "●"
+        }
+      ]
+    },
+    "div": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\div"
+        },
+        {
+          "type": "STRING",
+          "value": "÷"
+        }
+      ]
+    },
+    "circ": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\circ"
+        },
+        {
+          "type": "STRING",
+          "value": "∘"
+        }
+      ]
+    },
+    "star": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\star"
+        },
+        {
+          "type": "STRING",
+          "value": "⋆"
+        }
+      ]
+    },
+    "excl": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "!!"
+        },
+        {
+          "type": "STRING",
+          "value": "‼"
+        }
+      ]
+    },
+    "qq": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "??"
+        },
+        {
+          "type": "STRING",
+          "value": "⁇"
+        }
+      ]
+    },
+    "hashhash": {
+      "type": "STRING",
+      "value": "##"
+    },
+    "dol": {
+      "type": "STRING",
+      "value": "$"
+    },
+    "doldol": {
+      "type": "STRING",
+      "value": "$$"
+    },
+    "sqcap": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\sqcap"
+        },
+        {
+          "type": "STRING",
+          "value": "⊓"
+        }
+      ]
+    },
+    "sqcup": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\sqcup"
+        },
+        {
+          "type": "STRING",
+          "value": "⊔"
+        }
+      ]
+    },
+    "uplus": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\uplus"
+        },
+        {
+          "type": "STRING",
+          "value": "⊎"
+        }
+      ]
+    },
+    "times": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\X"
+        },
+        {
+          "type": "STRING",
+          "value": "\\times"
+        },
+        {
+          "type": "STRING",
+          "value": "×"
+        }
+      ]
+    },
+    "wr": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\wr"
+        },
+        {
+          "type": "STRING",
+          "value": "≀"
+        }
+      ]
+    },
+    "cdot": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\cdot"
+        },
+        {
+          "type": "STRING",
+          "value": "⋅"
+        }
+      ]
+    },
+    "pow": {
+      "type": "STRING",
+      "value": "^"
+    },
+    "powpow": {
+      "type": "STRING",
+      "value": "^^"
+    },
+    "infix_op_symbol": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "implies"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "plus_arrow"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "equiv"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "iff"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "leads_to"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "land"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "lor"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "assign"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "bnf_rule"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "eq"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "neq"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "lt"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "gt"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "leq"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "geq"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "approx"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "rs_ttile"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "rd_ttile"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "ls_ttile"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "ld_ttile"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "asymp"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "cong"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "doteq"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "gg"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "ll"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "in"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "notin"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "prec"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "succ"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "preceq"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "succeq"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "sim"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "simeq"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "sqsubset"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "sqsupset"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "sqsubseteq"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "sqsupseteq"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "compose"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "map_to"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "map_from"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "setminus"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "cap"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "cup"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "dots_2"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "dots_3"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "plus"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "plusplus"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "oplus"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "ominus"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "mod"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "modmod"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "vert"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "vertvert"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "minus"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "minusminus"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "amp"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "ampamp"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "odot"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "oslash"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "otimes"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "mul"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "mulmul"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "slash"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "slashslash"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "bigcirc"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "bullet"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "div"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "circ"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "star"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "excl"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "hashhash"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "dol"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "doldol"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "qq"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "sqcap"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "sqcup"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "uplus"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "wr"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "cdot"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "pow"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "powpow"
+        }
+      ]
+    },
+    "bound_infix_op": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "PREC_LEFT",
+          "value": 1,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "lhs",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expr"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "symbol",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "implies"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "plus_arrow"
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "rhs",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expr"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 2,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "lhs",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expr"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "symbol",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "equiv"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "iff"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "leads_to"
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "rhs",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expr"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 3,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "lhs",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expr"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "symbol",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "land"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "lor"
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "rhs",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expr"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 5,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "lhs",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expr"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "symbol",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "assign"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "bnf_rule"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "eq"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "neq"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "lt"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "gt"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "leq"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "geq"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "approx"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "rs_ttile"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "rd_ttile"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "ls_ttile"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "ld_ttile"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "asymp"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "cong"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "doteq"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "gg"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "ll"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "in"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "notin"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "prec"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "succ"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "preceq"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "succeq"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "propto"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "sim"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "simeq"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "sqsubset"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "sqsupset"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "sqsubseteq"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "sqsupseteq"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "subset"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "supset"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "subseteq"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "supseteq"
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "rhs",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expr"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 6,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "lhs",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expr"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "symbol",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "compose"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "rhs",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expr"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 7,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "lhs",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expr"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "symbol",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "map_to"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "map_from"
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "rhs",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expr"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 8,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "lhs",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expr"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "symbol",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "setminus"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "cap"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "cup"
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "rhs",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expr"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 9,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "lhs",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expr"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "symbol",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "dots_2"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "dots_3"
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "rhs",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expr"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 10,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "lhs",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expr"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "symbol",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "plus"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "plusplus"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "oplus"
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "rhs",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expr"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 11,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "lhs",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expr"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "symbol",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "ominus"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "mod"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "modmod"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "vert"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "vertvert"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "minus"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "minusminus"
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "rhs",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expr"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 13,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "lhs",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expr"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "symbol",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "amp"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "ampamp"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "odot"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "oslash"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "otimes"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "mul"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "mulmul"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "slash"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "slashslash"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "bigcirc"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "bullet"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "div"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "circ"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "star"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "excl"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "hashhash"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "dol"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "doldol"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "qq"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "sqcap"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "sqcup"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "uplus"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "times"
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "rhs",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expr"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 14,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "lhs",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expr"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "symbol",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "wr"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "cdot"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "pow"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "powpow"
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "rhs",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expr"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "sup_plus": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "^+"
+        },
+        {
+          "type": "STRING",
+          "value": "⁺"
+        }
+      ]
+    },
+    "asterisk": {
+      "type": "STRING",
+      "value": "^*"
+    },
+    "sup_hash": {
+      "type": "STRING",
+      "value": "^#"
+    },
+    "prime": {
+      "type": "STRING",
+      "value": "'"
+    },
+    "postfix_op_symbol": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "sup_plus"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "asterisk"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "sup_hash"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "prime"
+        }
+      ]
+    },
+    "bound_postfix_op": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "PREC",
+          "value": 15,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "lhs",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_expr"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "symbol",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "postfix_op_symbol"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "assumption": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "ASSUME"
+            },
+            {
+              "type": "STRING",
+              "value": "ASSUMPTION"
+            },
+            {
+              "type": "STRING",
+              "value": "AXIOM"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "def_eq"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expr"
+        }
+      ]
+    },
+    "theorem": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "THEOREM"
+            },
+            {
+              "type": "STRING",
+              "value": "PROPOSITION"
+            },
+            {
+              "type": "STRING",
+              "value": "LEMMA"
+            },
+            {
+              "type": "STRING",
+              "value": "COROLLARY"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "def_eq"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_expr"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "assume_prove"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "proof"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "assume_prove": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "ASSUME"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_expr"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "new"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "inner_assume_prove"
+                }
+              ]
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_expr"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "new"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "inner_assume_prove"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "PROVE"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expr"
+        }
+      ]
+    },
+    "inner_assume_prove": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "label_as"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "assume_prove"
+        }
+      ]
+    },
+    "new": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "NEW"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "level"
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "NEW"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "level"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "set_in"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_expr"
+                }
+              ]
+            },
+            {
+              "type": "SYMBOL",
+              "name": "operator_declaration"
+            }
+          ]
+        }
+      ]
+    },
+    "level": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "CONSTANT"
+        },
+        {
+          "type": "STRING",
+          "value": "VARIABLE"
+        },
+        {
+          "type": "STRING",
+          "value": "STATE"
+        },
+        {
+          "type": "STRING",
+          "value": "ACTION"
+        },
+        {
+          "type": "STRING",
+          "value": "TEMPORAL"
+        }
+      ]
+    },
+    "proof": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "terminal_proof"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "non_terminal_proof"
+        }
+      ]
+    },
+    "terminal_proof": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "PROOF"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "STRING",
+              "value": "BY"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "ONLY"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "SYMBOL",
+              "name": "use_body"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "OBVIOUS"
+        },
+        {
+          "type": "STRING",
+          "value": "OMITTED"
+        }
+      ]
+    },
+    "non_terminal_proof": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "PROOF"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "proof_step"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "qed_step"
+        }
+      ]
+    },
+    "proof_step": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "begin_proof_step_token"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "use_or_hide"
+                },
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": "DEFINE"
+                        },
+                        {
+                          "type": "BLANK"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "REPEAT1",
+                      "content": {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "SYMBOL",
+                            "name": "operator_definition"
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "function_definition"
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "module_definition"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "instance"
+                },
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "HAVE"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_expr"
+                    }
+                  ]
+                },
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "WITNESS"
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "_expr"
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": ","
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "_expr"
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "TAKE"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "bound_or_identifier_list"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "STRING",
+                              "value": "SUFFICES"
+                            },
+                            {
+                              "type": "BLANK"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "SYMBOL",
+                              "name": "_expr"
+                            },
+                            {
+                              "type": "SYMBOL",
+                              "name": "assume_prove"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": "CASE"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "_expr"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": "PICK"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "bound_or_identifier_list"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": ":"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "_expr"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "proof"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "bound_or_identifier_list": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "quantifier_bound"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "quantifier_bound"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "identifier"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "qed_step": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "begin_proof_step_token"
+        },
+        {
+          "type": "STRING",
+          "value": "QED"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "proof"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
+    "use_or_hide": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "USE"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "ONLY"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "STRING",
+              "value": "HIDE"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "use_body"
+        }
+      ]
+    },
+    "use_body": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "use_body_expr"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "use_body_def"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "use_body_expr"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "use_body_def"
+            }
+          ]
+        }
+      ]
+    },
+    "use_body_expr": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_expr"
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "MODULE"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": ","
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_expr"
+                  },
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "MODULE"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "identifier"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "use_body_def": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "DEF"
+            },
+            {
+              "type": "STRING",
+              "value": "DEFS"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "op_or_expr"
+                },
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "MODULE"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "identifier"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "op_or_expr"
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "MODULE"
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "identifier"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "begin_proof_step_token": {
+      "type": "PATTERN",
+      "value": "<[\\d+|\\*|\\+]>[\\w|\\d]+\\.*"
+    },
+    "proof_step_id": {
+      "type": "PATTERN",
+      "value": "<[\\d+|\\*]>[\\w|\\d]+"
+    }
+  },
+  "extras": [
+    {
+      "type": "PATTERN",
+      "value": "\\s|\\r?\\n"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "single_line_comment"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "multi_line_comment"
+    }
+  ],
+  "conflicts": [
+    [
+      "minus",
+      "negative"
+    ],
+    [
+      "bound_op",
+      "_subscript_expr"
+    ],
+    [
+      "bound_op",
+      "prefixed_op"
+    ],
+    [
+      "_expr",
+      "label"
+    ],
+    [
+      "_expr",
+      "quantifier_bound"
+    ],
+    [
+      "_expr",
+      "single_quantifier_bound"
+    ],
+    [
+      "_expr",
+      "tuple_of_identifiers"
+    ],
+    [
+      "_expr",
+      "operator_definition"
+    ],
+    [
+      "_expr",
+      "operator_declaration",
+      "label"
+    ],
+    [
+      "_expr",
+      "function_definition"
+    ],
+    [
+      "subexpr_prefix"
+    ],
+    [
+      "proof_step"
+    ],
+    [
+      "qed_step"
+    ]
+  ],
+  "precedences": [],
+  "externals": [
+    {
+      "type": "SYMBOL",
+      "name": "_indent"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_newline"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_dedent"
+    }
+  ],
+  "inline": [],
+  "supertypes": []
+}
+

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1,0 +1,10647 @@
+[
+  {
+    "type": "address",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "all_map_to",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "always",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "approx",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "assign",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "assume_prove",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "bound_infix_op",
+          "named": true
+        },
+        {
+          "type": "bound_nonfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_op",
+          "named": true
+        },
+        {
+          "type": "bound_postfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_prefix_op",
+          "named": true
+        },
+        {
+          "type": "bounded_quantification",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "choose",
+          "named": true
+        },
+        {
+          "type": "conj_list",
+          "named": true
+        },
+        {
+          "type": "disj_list",
+          "named": true
+        },
+        {
+          "type": "except",
+          "named": true
+        },
+        {
+          "type": "fairness",
+          "named": true
+        },
+        {
+          "type": "finite_set_literal",
+          "named": true
+        },
+        {
+          "type": "function_evaluation",
+          "named": true
+        },
+        {
+          "type": "function_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "if_then_else",
+          "named": true
+        },
+        {
+          "type": "inner_assume_prove",
+          "named": true
+        },
+        {
+          "type": "label",
+          "named": true
+        },
+        {
+          "type": "let_in",
+          "named": true
+        },
+        {
+          "type": "new",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "parentheses",
+          "named": true
+        },
+        {
+          "type": "prefixed_op",
+          "named": true
+        },
+        {
+          "type": "prev_func_val",
+          "named": true
+        },
+        {
+          "type": "primitive_value_set",
+          "named": true
+        },
+        {
+          "type": "proof_step_id",
+          "named": true
+        },
+        {
+          "type": "record_literal",
+          "named": true
+        },
+        {
+          "type": "record_value",
+          "named": true
+        },
+        {
+          "type": "set_filter",
+          "named": true
+        },
+        {
+          "type": "set_map",
+          "named": true
+        },
+        {
+          "type": "set_of_functions",
+          "named": true
+        },
+        {
+          "type": "set_of_records",
+          "named": true
+        },
+        {
+          "type": "step_expr_no_stutter",
+          "named": true
+        },
+        {
+          "type": "step_expr_or_stutter",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "subexpression",
+          "named": true
+        },
+        {
+          "type": "tuple_literal",
+          "named": true
+        },
+        {
+          "type": "unbounded_quantification",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "assumption",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "bound_infix_op",
+          "named": true
+        },
+        {
+          "type": "bound_nonfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_op",
+          "named": true
+        },
+        {
+          "type": "bound_postfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_prefix_op",
+          "named": true
+        },
+        {
+          "type": "bounded_quantification",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "choose",
+          "named": true
+        },
+        {
+          "type": "conj_list",
+          "named": true
+        },
+        {
+          "type": "def_eq",
+          "named": true
+        },
+        {
+          "type": "disj_list",
+          "named": true
+        },
+        {
+          "type": "except",
+          "named": true
+        },
+        {
+          "type": "fairness",
+          "named": true
+        },
+        {
+          "type": "finite_set_literal",
+          "named": true
+        },
+        {
+          "type": "function_evaluation",
+          "named": true
+        },
+        {
+          "type": "function_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "if_then_else",
+          "named": true
+        },
+        {
+          "type": "label",
+          "named": true
+        },
+        {
+          "type": "let_in",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "parentheses",
+          "named": true
+        },
+        {
+          "type": "prefixed_op",
+          "named": true
+        },
+        {
+          "type": "prev_func_val",
+          "named": true
+        },
+        {
+          "type": "primitive_value_set",
+          "named": true
+        },
+        {
+          "type": "proof_step_id",
+          "named": true
+        },
+        {
+          "type": "record_literal",
+          "named": true
+        },
+        {
+          "type": "record_value",
+          "named": true
+        },
+        {
+          "type": "set_filter",
+          "named": true
+        },
+        {
+          "type": "set_map",
+          "named": true
+        },
+        {
+          "type": "set_of_functions",
+          "named": true
+        },
+        {
+          "type": "set_of_records",
+          "named": true
+        },
+        {
+          "type": "step_expr_no_stutter",
+          "named": true
+        },
+        {
+          "type": "step_expr_or_stutter",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "subexpression",
+          "named": true
+        },
+        {
+          "type": "tuple_literal",
+          "named": true
+        },
+        {
+          "type": "unbounded_quantification",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "asymp",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "bigcirc",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "bnf_rule",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "boolean",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "bound_infix_op",
+    "named": true,
+    "fields": {
+      "lhs": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "boolean",
+            "named": true
+          },
+          {
+            "type": "bound_infix_op",
+            "named": true
+          },
+          {
+            "type": "bound_nonfix_op",
+            "named": true
+          },
+          {
+            "type": "bound_op",
+            "named": true
+          },
+          {
+            "type": "bound_postfix_op",
+            "named": true
+          },
+          {
+            "type": "bound_prefix_op",
+            "named": true
+          },
+          {
+            "type": "bounded_quantification",
+            "named": true
+          },
+          {
+            "type": "case",
+            "named": true
+          },
+          {
+            "type": "choose",
+            "named": true
+          },
+          {
+            "type": "conj_list",
+            "named": true
+          },
+          {
+            "type": "disj_list",
+            "named": true
+          },
+          {
+            "type": "except",
+            "named": true
+          },
+          {
+            "type": "fairness",
+            "named": true
+          },
+          {
+            "type": "finite_set_literal",
+            "named": true
+          },
+          {
+            "type": "function_evaluation",
+            "named": true
+          },
+          {
+            "type": "function_literal",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "if_then_else",
+            "named": true
+          },
+          {
+            "type": "label",
+            "named": true
+          },
+          {
+            "type": "let_in",
+            "named": true
+          },
+          {
+            "type": "number",
+            "named": true
+          },
+          {
+            "type": "parentheses",
+            "named": true
+          },
+          {
+            "type": "prefixed_op",
+            "named": true
+          },
+          {
+            "type": "prev_func_val",
+            "named": true
+          },
+          {
+            "type": "primitive_value_set",
+            "named": true
+          },
+          {
+            "type": "proof_step_id",
+            "named": true
+          },
+          {
+            "type": "record_literal",
+            "named": true
+          },
+          {
+            "type": "record_value",
+            "named": true
+          },
+          {
+            "type": "set_filter",
+            "named": true
+          },
+          {
+            "type": "set_map",
+            "named": true
+          },
+          {
+            "type": "set_of_functions",
+            "named": true
+          },
+          {
+            "type": "set_of_records",
+            "named": true
+          },
+          {
+            "type": "step_expr_no_stutter",
+            "named": true
+          },
+          {
+            "type": "step_expr_or_stutter",
+            "named": true
+          },
+          {
+            "type": "string",
+            "named": true
+          },
+          {
+            "type": "subexpression",
+            "named": true
+          },
+          {
+            "type": "tuple_literal",
+            "named": true
+          },
+          {
+            "type": "unbounded_quantification",
+            "named": true
+          }
+        ]
+      },
+      "rhs": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "boolean",
+            "named": true
+          },
+          {
+            "type": "bound_infix_op",
+            "named": true
+          },
+          {
+            "type": "bound_nonfix_op",
+            "named": true
+          },
+          {
+            "type": "bound_op",
+            "named": true
+          },
+          {
+            "type": "bound_postfix_op",
+            "named": true
+          },
+          {
+            "type": "bound_prefix_op",
+            "named": true
+          },
+          {
+            "type": "bounded_quantification",
+            "named": true
+          },
+          {
+            "type": "case",
+            "named": true
+          },
+          {
+            "type": "choose",
+            "named": true
+          },
+          {
+            "type": "conj_list",
+            "named": true
+          },
+          {
+            "type": "disj_list",
+            "named": true
+          },
+          {
+            "type": "except",
+            "named": true
+          },
+          {
+            "type": "fairness",
+            "named": true
+          },
+          {
+            "type": "finite_set_literal",
+            "named": true
+          },
+          {
+            "type": "function_evaluation",
+            "named": true
+          },
+          {
+            "type": "function_literal",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "if_then_else",
+            "named": true
+          },
+          {
+            "type": "label",
+            "named": true
+          },
+          {
+            "type": "let_in",
+            "named": true
+          },
+          {
+            "type": "number",
+            "named": true
+          },
+          {
+            "type": "parentheses",
+            "named": true
+          },
+          {
+            "type": "prefixed_op",
+            "named": true
+          },
+          {
+            "type": "prev_func_val",
+            "named": true
+          },
+          {
+            "type": "primitive_value_set",
+            "named": true
+          },
+          {
+            "type": "proof_step_id",
+            "named": true
+          },
+          {
+            "type": "record_literal",
+            "named": true
+          },
+          {
+            "type": "record_value",
+            "named": true
+          },
+          {
+            "type": "set_filter",
+            "named": true
+          },
+          {
+            "type": "set_map",
+            "named": true
+          },
+          {
+            "type": "set_of_functions",
+            "named": true
+          },
+          {
+            "type": "set_of_records",
+            "named": true
+          },
+          {
+            "type": "step_expr_no_stutter",
+            "named": true
+          },
+          {
+            "type": "step_expr_or_stutter",
+            "named": true
+          },
+          {
+            "type": "string",
+            "named": true
+          },
+          {
+            "type": "subexpression",
+            "named": true
+          },
+          {
+            "type": "tuple_literal",
+            "named": true
+          },
+          {
+            "type": "unbounded_quantification",
+            "named": true
+          }
+        ]
+      },
+      "symbol": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "amp",
+            "named": true
+          },
+          {
+            "type": "ampamp",
+            "named": true
+          },
+          {
+            "type": "approx",
+            "named": true
+          },
+          {
+            "type": "assign",
+            "named": true
+          },
+          {
+            "type": "asymp",
+            "named": true
+          },
+          {
+            "type": "bigcirc",
+            "named": true
+          },
+          {
+            "type": "bnf_rule",
+            "named": true
+          },
+          {
+            "type": "bullet",
+            "named": true
+          },
+          {
+            "type": "cap",
+            "named": true
+          },
+          {
+            "type": "cdot",
+            "named": true
+          },
+          {
+            "type": "circ",
+            "named": true
+          },
+          {
+            "type": "compose",
+            "named": true
+          },
+          {
+            "type": "cong",
+            "named": true
+          },
+          {
+            "type": "cup",
+            "named": true
+          },
+          {
+            "type": "div",
+            "named": true
+          },
+          {
+            "type": "dol",
+            "named": true
+          },
+          {
+            "type": "doldol",
+            "named": true
+          },
+          {
+            "type": "doteq",
+            "named": true
+          },
+          {
+            "type": "dots_2",
+            "named": true
+          },
+          {
+            "type": "dots_3",
+            "named": true
+          },
+          {
+            "type": "eq",
+            "named": true
+          },
+          {
+            "type": "equiv",
+            "named": true
+          },
+          {
+            "type": "excl",
+            "named": true
+          },
+          {
+            "type": "geq",
+            "named": true
+          },
+          {
+            "type": "gg",
+            "named": true
+          },
+          {
+            "type": "gt",
+            "named": true
+          },
+          {
+            "type": "hashhash",
+            "named": true
+          },
+          {
+            "type": "iff",
+            "named": true
+          },
+          {
+            "type": "implies",
+            "named": true
+          },
+          {
+            "type": "in",
+            "named": true
+          },
+          {
+            "type": "land",
+            "named": true
+          },
+          {
+            "type": "ld_ttile",
+            "named": true
+          },
+          {
+            "type": "leads_to",
+            "named": true
+          },
+          {
+            "type": "leq",
+            "named": true
+          },
+          {
+            "type": "ll",
+            "named": true
+          },
+          {
+            "type": "lor",
+            "named": true
+          },
+          {
+            "type": "ls_ttile",
+            "named": true
+          },
+          {
+            "type": "lt",
+            "named": true
+          },
+          {
+            "type": "map_from",
+            "named": true
+          },
+          {
+            "type": "map_to",
+            "named": true
+          },
+          {
+            "type": "minus",
+            "named": true
+          },
+          {
+            "type": "minusminus",
+            "named": true
+          },
+          {
+            "type": "mod",
+            "named": true
+          },
+          {
+            "type": "modmod",
+            "named": true
+          },
+          {
+            "type": "mul",
+            "named": true
+          },
+          {
+            "type": "mulmul",
+            "named": true
+          },
+          {
+            "type": "neq",
+            "named": true
+          },
+          {
+            "type": "notin",
+            "named": true
+          },
+          {
+            "type": "odot",
+            "named": true
+          },
+          {
+            "type": "ominus",
+            "named": true
+          },
+          {
+            "type": "oplus",
+            "named": true
+          },
+          {
+            "type": "oslash",
+            "named": true
+          },
+          {
+            "type": "otimes",
+            "named": true
+          },
+          {
+            "type": "plus",
+            "named": true
+          },
+          {
+            "type": "plus_arrow",
+            "named": true
+          },
+          {
+            "type": "plusplus",
+            "named": true
+          },
+          {
+            "type": "pow",
+            "named": true
+          },
+          {
+            "type": "powpow",
+            "named": true
+          },
+          {
+            "type": "prec",
+            "named": true
+          },
+          {
+            "type": "preceq",
+            "named": true
+          },
+          {
+            "type": "propto",
+            "named": true
+          },
+          {
+            "type": "qq",
+            "named": true
+          },
+          {
+            "type": "rd_ttile",
+            "named": true
+          },
+          {
+            "type": "rs_ttile",
+            "named": true
+          },
+          {
+            "type": "setminus",
+            "named": true
+          },
+          {
+            "type": "sim",
+            "named": true
+          },
+          {
+            "type": "simeq",
+            "named": true
+          },
+          {
+            "type": "slash",
+            "named": true
+          },
+          {
+            "type": "slashslash",
+            "named": true
+          },
+          {
+            "type": "sqcap",
+            "named": true
+          },
+          {
+            "type": "sqcup",
+            "named": true
+          },
+          {
+            "type": "sqsubset",
+            "named": true
+          },
+          {
+            "type": "sqsubseteq",
+            "named": true
+          },
+          {
+            "type": "sqsupset",
+            "named": true
+          },
+          {
+            "type": "sqsupseteq",
+            "named": true
+          },
+          {
+            "type": "star",
+            "named": true
+          },
+          {
+            "type": "subset",
+            "named": true
+          },
+          {
+            "type": "subseteq",
+            "named": true
+          },
+          {
+            "type": "succ",
+            "named": true
+          },
+          {
+            "type": "succeq",
+            "named": true
+          },
+          {
+            "type": "supset",
+            "named": true
+          },
+          {
+            "type": "supseteq",
+            "named": true
+          },
+          {
+            "type": "times",
+            "named": true
+          },
+          {
+            "type": "uplus",
+            "named": true
+          },
+          {
+            "type": "vert",
+            "named": true
+          },
+          {
+            "type": "vertvert",
+            "named": true
+          },
+          {
+            "type": "wr",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "bound_nonfix_op",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "bound_infix_op",
+          "named": true
+        },
+        {
+          "type": "bound_nonfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_op",
+          "named": true
+        },
+        {
+          "type": "bound_postfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_prefix_op",
+          "named": true
+        },
+        {
+          "type": "bounded_quantification",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "choose",
+          "named": true
+        },
+        {
+          "type": "conj_list",
+          "named": true
+        },
+        {
+          "type": "disj_list",
+          "named": true
+        },
+        {
+          "type": "except",
+          "named": true
+        },
+        {
+          "type": "fairness",
+          "named": true
+        },
+        {
+          "type": "finite_set_literal",
+          "named": true
+        },
+        {
+          "type": "function_evaluation",
+          "named": true
+        },
+        {
+          "type": "function_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "if_then_else",
+          "named": true
+        },
+        {
+          "type": "infix_op_symbol",
+          "named": true
+        },
+        {
+          "type": "label",
+          "named": true
+        },
+        {
+          "type": "let_in",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "parentheses",
+          "named": true
+        },
+        {
+          "type": "postfix_op_symbol",
+          "named": true
+        },
+        {
+          "type": "prefixed_op",
+          "named": true
+        },
+        {
+          "type": "prev_func_val",
+          "named": true
+        },
+        {
+          "type": "primitive_value_set",
+          "named": true
+        },
+        {
+          "type": "proof_step_id",
+          "named": true
+        },
+        {
+          "type": "record_literal",
+          "named": true
+        },
+        {
+          "type": "record_value",
+          "named": true
+        },
+        {
+          "type": "set_filter",
+          "named": true
+        },
+        {
+          "type": "set_map",
+          "named": true
+        },
+        {
+          "type": "set_of_functions",
+          "named": true
+        },
+        {
+          "type": "set_of_records",
+          "named": true
+        },
+        {
+          "type": "standalone_prefix_op_symbol",
+          "named": true
+        },
+        {
+          "type": "step_expr_no_stutter",
+          "named": true
+        },
+        {
+          "type": "step_expr_or_stutter",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "subexpression",
+          "named": true
+        },
+        {
+          "type": "tuple_literal",
+          "named": true
+        },
+        {
+          "type": "unbounded_quantification",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "bound_op",
+    "named": true,
+    "fields": {
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      },
+      "parameters": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "(",
+            "named": false
+          },
+          {
+            "type": ")",
+            "named": false
+          },
+          {
+            "type": ",",
+            "named": false
+          },
+          {
+            "type": "op_or_expr",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "bound_or_identifier_list",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "quantifier_bound",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "bound_postfix_op",
+    "named": true,
+    "fields": {
+      "lhs": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "boolean",
+            "named": true
+          },
+          {
+            "type": "bound_infix_op",
+            "named": true
+          },
+          {
+            "type": "bound_nonfix_op",
+            "named": true
+          },
+          {
+            "type": "bound_op",
+            "named": true
+          },
+          {
+            "type": "bound_postfix_op",
+            "named": true
+          },
+          {
+            "type": "bound_prefix_op",
+            "named": true
+          },
+          {
+            "type": "bounded_quantification",
+            "named": true
+          },
+          {
+            "type": "case",
+            "named": true
+          },
+          {
+            "type": "choose",
+            "named": true
+          },
+          {
+            "type": "conj_list",
+            "named": true
+          },
+          {
+            "type": "disj_list",
+            "named": true
+          },
+          {
+            "type": "except",
+            "named": true
+          },
+          {
+            "type": "fairness",
+            "named": true
+          },
+          {
+            "type": "finite_set_literal",
+            "named": true
+          },
+          {
+            "type": "function_evaluation",
+            "named": true
+          },
+          {
+            "type": "function_literal",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "if_then_else",
+            "named": true
+          },
+          {
+            "type": "label",
+            "named": true
+          },
+          {
+            "type": "let_in",
+            "named": true
+          },
+          {
+            "type": "number",
+            "named": true
+          },
+          {
+            "type": "parentheses",
+            "named": true
+          },
+          {
+            "type": "prefixed_op",
+            "named": true
+          },
+          {
+            "type": "prev_func_val",
+            "named": true
+          },
+          {
+            "type": "primitive_value_set",
+            "named": true
+          },
+          {
+            "type": "proof_step_id",
+            "named": true
+          },
+          {
+            "type": "record_literal",
+            "named": true
+          },
+          {
+            "type": "record_value",
+            "named": true
+          },
+          {
+            "type": "set_filter",
+            "named": true
+          },
+          {
+            "type": "set_map",
+            "named": true
+          },
+          {
+            "type": "set_of_functions",
+            "named": true
+          },
+          {
+            "type": "set_of_records",
+            "named": true
+          },
+          {
+            "type": "step_expr_no_stutter",
+            "named": true
+          },
+          {
+            "type": "step_expr_or_stutter",
+            "named": true
+          },
+          {
+            "type": "string",
+            "named": true
+          },
+          {
+            "type": "subexpression",
+            "named": true
+          },
+          {
+            "type": "tuple_literal",
+            "named": true
+          },
+          {
+            "type": "unbounded_quantification",
+            "named": true
+          }
+        ]
+      },
+      "symbol": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "postfix_op_symbol",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "bound_prefix_op",
+    "named": true,
+    "fields": {
+      "rhs": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "boolean",
+            "named": true
+          },
+          {
+            "type": "bound_infix_op",
+            "named": true
+          },
+          {
+            "type": "bound_nonfix_op",
+            "named": true
+          },
+          {
+            "type": "bound_op",
+            "named": true
+          },
+          {
+            "type": "bound_postfix_op",
+            "named": true
+          },
+          {
+            "type": "bound_prefix_op",
+            "named": true
+          },
+          {
+            "type": "bounded_quantification",
+            "named": true
+          },
+          {
+            "type": "case",
+            "named": true
+          },
+          {
+            "type": "choose",
+            "named": true
+          },
+          {
+            "type": "conj_list",
+            "named": true
+          },
+          {
+            "type": "disj_list",
+            "named": true
+          },
+          {
+            "type": "except",
+            "named": true
+          },
+          {
+            "type": "fairness",
+            "named": true
+          },
+          {
+            "type": "finite_set_literal",
+            "named": true
+          },
+          {
+            "type": "function_evaluation",
+            "named": true
+          },
+          {
+            "type": "function_literal",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "if_then_else",
+            "named": true
+          },
+          {
+            "type": "label",
+            "named": true
+          },
+          {
+            "type": "let_in",
+            "named": true
+          },
+          {
+            "type": "number",
+            "named": true
+          },
+          {
+            "type": "parentheses",
+            "named": true
+          },
+          {
+            "type": "prefixed_op",
+            "named": true
+          },
+          {
+            "type": "prev_func_val",
+            "named": true
+          },
+          {
+            "type": "primitive_value_set",
+            "named": true
+          },
+          {
+            "type": "proof_step_id",
+            "named": true
+          },
+          {
+            "type": "record_literal",
+            "named": true
+          },
+          {
+            "type": "record_value",
+            "named": true
+          },
+          {
+            "type": "set_filter",
+            "named": true
+          },
+          {
+            "type": "set_map",
+            "named": true
+          },
+          {
+            "type": "set_of_functions",
+            "named": true
+          },
+          {
+            "type": "set_of_records",
+            "named": true
+          },
+          {
+            "type": "step_expr_no_stutter",
+            "named": true
+          },
+          {
+            "type": "step_expr_or_stutter",
+            "named": true
+          },
+          {
+            "type": "string",
+            "named": true
+          },
+          {
+            "type": "subexpression",
+            "named": true
+          },
+          {
+            "type": "tuple_literal",
+            "named": true
+          },
+          {
+            "type": "unbounded_quantification",
+            "named": true
+          }
+        ]
+      },
+      "symbol": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "always",
+            "named": true
+          },
+          {
+            "type": "domain",
+            "named": true
+          },
+          {
+            "type": "enabled",
+            "named": true
+          },
+          {
+            "type": "eventually",
+            "named": true
+          },
+          {
+            "type": "lnot",
+            "named": true
+          },
+          {
+            "type": "negative",
+            "named": true
+          },
+          {
+            "type": "powerset",
+            "named": true
+          },
+          {
+            "type": "unchanged",
+            "named": true
+          },
+          {
+            "type": "union",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "bounded_quantification",
+    "named": true,
+    "fields": {
+      "bound": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": ",",
+            "named": false
+          },
+          {
+            "type": "quantifier_bound",
+            "named": true
+          }
+        ]
+      },
+      "expression": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "boolean",
+            "named": true
+          },
+          {
+            "type": "bound_infix_op",
+            "named": true
+          },
+          {
+            "type": "bound_nonfix_op",
+            "named": true
+          },
+          {
+            "type": "bound_op",
+            "named": true
+          },
+          {
+            "type": "bound_postfix_op",
+            "named": true
+          },
+          {
+            "type": "bound_prefix_op",
+            "named": true
+          },
+          {
+            "type": "bounded_quantification",
+            "named": true
+          },
+          {
+            "type": "case",
+            "named": true
+          },
+          {
+            "type": "choose",
+            "named": true
+          },
+          {
+            "type": "conj_list",
+            "named": true
+          },
+          {
+            "type": "disj_list",
+            "named": true
+          },
+          {
+            "type": "except",
+            "named": true
+          },
+          {
+            "type": "fairness",
+            "named": true
+          },
+          {
+            "type": "finite_set_literal",
+            "named": true
+          },
+          {
+            "type": "function_evaluation",
+            "named": true
+          },
+          {
+            "type": "function_literal",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "if_then_else",
+            "named": true
+          },
+          {
+            "type": "label",
+            "named": true
+          },
+          {
+            "type": "let_in",
+            "named": true
+          },
+          {
+            "type": "number",
+            "named": true
+          },
+          {
+            "type": "parentheses",
+            "named": true
+          },
+          {
+            "type": "prefixed_op",
+            "named": true
+          },
+          {
+            "type": "prev_func_val",
+            "named": true
+          },
+          {
+            "type": "primitive_value_set",
+            "named": true
+          },
+          {
+            "type": "proof_step_id",
+            "named": true
+          },
+          {
+            "type": "record_literal",
+            "named": true
+          },
+          {
+            "type": "record_value",
+            "named": true
+          },
+          {
+            "type": "set_filter",
+            "named": true
+          },
+          {
+            "type": "set_map",
+            "named": true
+          },
+          {
+            "type": "set_of_functions",
+            "named": true
+          },
+          {
+            "type": "set_of_records",
+            "named": true
+          },
+          {
+            "type": "step_expr_no_stutter",
+            "named": true
+          },
+          {
+            "type": "step_expr_or_stutter",
+            "named": true
+          },
+          {
+            "type": "string",
+            "named": true
+          },
+          {
+            "type": "subexpression",
+            "named": true
+          },
+          {
+            "type": "tuple_literal",
+            "named": true
+          },
+          {
+            "type": "unbounded_quantification",
+            "named": true
+          }
+        ]
+      },
+      "quantifier": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "exists",
+            "named": true
+          },
+          {
+            "type": "forall",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "bullet",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "bullet_conj",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "bullet_disj",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "cap",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "case",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "case_arm",
+          "named": true
+        },
+        {
+          "type": "case_box",
+          "named": true
+        },
+        {
+          "type": "other_arm",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "case_arm",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "bound_infix_op",
+          "named": true
+        },
+        {
+          "type": "bound_nonfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_op",
+          "named": true
+        },
+        {
+          "type": "bound_postfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_prefix_op",
+          "named": true
+        },
+        {
+          "type": "bounded_quantification",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "case_arrow",
+          "named": true
+        },
+        {
+          "type": "choose",
+          "named": true
+        },
+        {
+          "type": "conj_list",
+          "named": true
+        },
+        {
+          "type": "disj_list",
+          "named": true
+        },
+        {
+          "type": "except",
+          "named": true
+        },
+        {
+          "type": "fairness",
+          "named": true
+        },
+        {
+          "type": "finite_set_literal",
+          "named": true
+        },
+        {
+          "type": "function_evaluation",
+          "named": true
+        },
+        {
+          "type": "function_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "if_then_else",
+          "named": true
+        },
+        {
+          "type": "label",
+          "named": true
+        },
+        {
+          "type": "let_in",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "parentheses",
+          "named": true
+        },
+        {
+          "type": "prefixed_op",
+          "named": true
+        },
+        {
+          "type": "prev_func_val",
+          "named": true
+        },
+        {
+          "type": "primitive_value_set",
+          "named": true
+        },
+        {
+          "type": "proof_step_id",
+          "named": true
+        },
+        {
+          "type": "record_literal",
+          "named": true
+        },
+        {
+          "type": "record_value",
+          "named": true
+        },
+        {
+          "type": "set_filter",
+          "named": true
+        },
+        {
+          "type": "set_map",
+          "named": true
+        },
+        {
+          "type": "set_of_functions",
+          "named": true
+        },
+        {
+          "type": "set_of_records",
+          "named": true
+        },
+        {
+          "type": "step_expr_no_stutter",
+          "named": true
+        },
+        {
+          "type": "step_expr_or_stutter",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "subexpression",
+          "named": true
+        },
+        {
+          "type": "tuple_literal",
+          "named": true
+        },
+        {
+          "type": "unbounded_quantification",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "case_arrow",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "case_box",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "cdot",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "choose",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "bound_infix_op",
+          "named": true
+        },
+        {
+          "type": "bound_nonfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_op",
+          "named": true
+        },
+        {
+          "type": "bound_postfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_prefix_op",
+          "named": true
+        },
+        {
+          "type": "bounded_quantification",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "choose",
+          "named": true
+        },
+        {
+          "type": "conj_list",
+          "named": true
+        },
+        {
+          "type": "disj_list",
+          "named": true
+        },
+        {
+          "type": "except",
+          "named": true
+        },
+        {
+          "type": "fairness",
+          "named": true
+        },
+        {
+          "type": "finite_set_literal",
+          "named": true
+        },
+        {
+          "type": "function_evaluation",
+          "named": true
+        },
+        {
+          "type": "function_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "if_then_else",
+          "named": true
+        },
+        {
+          "type": "label",
+          "named": true
+        },
+        {
+          "type": "let_in",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "parentheses",
+          "named": true
+        },
+        {
+          "type": "prefixed_op",
+          "named": true
+        },
+        {
+          "type": "prev_func_val",
+          "named": true
+        },
+        {
+          "type": "primitive_value_set",
+          "named": true
+        },
+        {
+          "type": "proof_step_id",
+          "named": true
+        },
+        {
+          "type": "record_literal",
+          "named": true
+        },
+        {
+          "type": "record_value",
+          "named": true
+        },
+        {
+          "type": "set_filter",
+          "named": true
+        },
+        {
+          "type": "set_in",
+          "named": true
+        },
+        {
+          "type": "set_map",
+          "named": true
+        },
+        {
+          "type": "set_of_functions",
+          "named": true
+        },
+        {
+          "type": "set_of_records",
+          "named": true
+        },
+        {
+          "type": "step_expr_no_stutter",
+          "named": true
+        },
+        {
+          "type": "step_expr_or_stutter",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "subexpression",
+          "named": true
+        },
+        {
+          "type": "tuple_literal",
+          "named": true
+        },
+        {
+          "type": "tuple_of_identifiers",
+          "named": true
+        },
+        {
+          "type": "unbounded_quantification",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "circ",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "colon",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "cong",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "conj_item",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "bound_infix_op",
+          "named": true
+        },
+        {
+          "type": "bound_nonfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_op",
+          "named": true
+        },
+        {
+          "type": "bound_postfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_prefix_op",
+          "named": true
+        },
+        {
+          "type": "bounded_quantification",
+          "named": true
+        },
+        {
+          "type": "bullet_conj",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "choose",
+          "named": true
+        },
+        {
+          "type": "conj_list",
+          "named": true
+        },
+        {
+          "type": "disj_list",
+          "named": true
+        },
+        {
+          "type": "except",
+          "named": true
+        },
+        {
+          "type": "fairness",
+          "named": true
+        },
+        {
+          "type": "finite_set_literal",
+          "named": true
+        },
+        {
+          "type": "function_evaluation",
+          "named": true
+        },
+        {
+          "type": "function_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "if_then_else",
+          "named": true
+        },
+        {
+          "type": "label",
+          "named": true
+        },
+        {
+          "type": "let_in",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "parentheses",
+          "named": true
+        },
+        {
+          "type": "prefixed_op",
+          "named": true
+        },
+        {
+          "type": "prev_func_val",
+          "named": true
+        },
+        {
+          "type": "primitive_value_set",
+          "named": true
+        },
+        {
+          "type": "proof_step_id",
+          "named": true
+        },
+        {
+          "type": "record_literal",
+          "named": true
+        },
+        {
+          "type": "record_value",
+          "named": true
+        },
+        {
+          "type": "set_filter",
+          "named": true
+        },
+        {
+          "type": "set_map",
+          "named": true
+        },
+        {
+          "type": "set_of_functions",
+          "named": true
+        },
+        {
+          "type": "set_of_records",
+          "named": true
+        },
+        {
+          "type": "step_expr_no_stutter",
+          "named": true
+        },
+        {
+          "type": "step_expr_or_stutter",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "subexpression",
+          "named": true
+        },
+        {
+          "type": "tuple_literal",
+          "named": true
+        },
+        {
+          "type": "unbounded_quantification",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "conj_list",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "conj_item",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "constant_declaration",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "operator_declaration",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "cup",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "def_eq",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "disj_item",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "bound_infix_op",
+          "named": true
+        },
+        {
+          "type": "bound_nonfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_op",
+          "named": true
+        },
+        {
+          "type": "bound_postfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_prefix_op",
+          "named": true
+        },
+        {
+          "type": "bounded_quantification",
+          "named": true
+        },
+        {
+          "type": "bullet_disj",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "choose",
+          "named": true
+        },
+        {
+          "type": "conj_list",
+          "named": true
+        },
+        {
+          "type": "disj_list",
+          "named": true
+        },
+        {
+          "type": "except",
+          "named": true
+        },
+        {
+          "type": "fairness",
+          "named": true
+        },
+        {
+          "type": "finite_set_literal",
+          "named": true
+        },
+        {
+          "type": "function_evaluation",
+          "named": true
+        },
+        {
+          "type": "function_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "if_then_else",
+          "named": true
+        },
+        {
+          "type": "label",
+          "named": true
+        },
+        {
+          "type": "let_in",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "parentheses",
+          "named": true
+        },
+        {
+          "type": "prefixed_op",
+          "named": true
+        },
+        {
+          "type": "prev_func_val",
+          "named": true
+        },
+        {
+          "type": "primitive_value_set",
+          "named": true
+        },
+        {
+          "type": "proof_step_id",
+          "named": true
+        },
+        {
+          "type": "record_literal",
+          "named": true
+        },
+        {
+          "type": "record_value",
+          "named": true
+        },
+        {
+          "type": "set_filter",
+          "named": true
+        },
+        {
+          "type": "set_map",
+          "named": true
+        },
+        {
+          "type": "set_of_functions",
+          "named": true
+        },
+        {
+          "type": "set_of_records",
+          "named": true
+        },
+        {
+          "type": "step_expr_no_stutter",
+          "named": true
+        },
+        {
+          "type": "step_expr_or_stutter",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "subexpression",
+          "named": true
+        },
+        {
+          "type": "tuple_literal",
+          "named": true
+        },
+        {
+          "type": "unbounded_quantification",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "disj_list",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "disj_item",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "div",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "domain",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "doteq",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "dots_2",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "dots_3",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "enabled",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "eq",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "equiv",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "eventually",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "except",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "bound_infix_op",
+          "named": true
+        },
+        {
+          "type": "bound_nonfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_op",
+          "named": true
+        },
+        {
+          "type": "bound_postfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_prefix_op",
+          "named": true
+        },
+        {
+          "type": "bounded_quantification",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "choose",
+          "named": true
+        },
+        {
+          "type": "conj_list",
+          "named": true
+        },
+        {
+          "type": "disj_list",
+          "named": true
+        },
+        {
+          "type": "except",
+          "named": true
+        },
+        {
+          "type": "fairness",
+          "named": true
+        },
+        {
+          "type": "finite_set_literal",
+          "named": true
+        },
+        {
+          "type": "function_evaluation",
+          "named": true
+        },
+        {
+          "type": "function_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "if_then_else",
+          "named": true
+        },
+        {
+          "type": "label",
+          "named": true
+        },
+        {
+          "type": "let_in",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "parentheses",
+          "named": true
+        },
+        {
+          "type": "prefixed_op",
+          "named": true
+        },
+        {
+          "type": "prev_func_val",
+          "named": true
+        },
+        {
+          "type": "primitive_value_set",
+          "named": true
+        },
+        {
+          "type": "proof_step_id",
+          "named": true
+        },
+        {
+          "type": "record_literal",
+          "named": true
+        },
+        {
+          "type": "record_value",
+          "named": true
+        },
+        {
+          "type": "set_filter",
+          "named": true
+        },
+        {
+          "type": "set_map",
+          "named": true
+        },
+        {
+          "type": "set_of_functions",
+          "named": true
+        },
+        {
+          "type": "set_of_records",
+          "named": true
+        },
+        {
+          "type": "step_expr_no_stutter",
+          "named": true
+        },
+        {
+          "type": "step_expr_or_stutter",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "subexpression",
+          "named": true
+        },
+        {
+          "type": "tuple_literal",
+          "named": true
+        },
+        {
+          "type": "unbounded_quantification",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "excl",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "exists",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "extends",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "fairness",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "bound_infix_op",
+          "named": true
+        },
+        {
+          "type": "bound_nonfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_op",
+          "named": true
+        },
+        {
+          "type": "bound_postfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_prefix_op",
+          "named": true
+        },
+        {
+          "type": "bounded_quantification",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "choose",
+          "named": true
+        },
+        {
+          "type": "conj_list",
+          "named": true
+        },
+        {
+          "type": "disj_list",
+          "named": true
+        },
+        {
+          "type": "except",
+          "named": true
+        },
+        {
+          "type": "fairness",
+          "named": true
+        },
+        {
+          "type": "finite_set_literal",
+          "named": true
+        },
+        {
+          "type": "function_evaluation",
+          "named": true
+        },
+        {
+          "type": "function_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "if_then_else",
+          "named": true
+        },
+        {
+          "type": "label",
+          "named": true
+        },
+        {
+          "type": "let_in",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "parentheses",
+          "named": true
+        },
+        {
+          "type": "prefixed_op",
+          "named": true
+        },
+        {
+          "type": "prev_func_val",
+          "named": true
+        },
+        {
+          "type": "primitive_value_set",
+          "named": true
+        },
+        {
+          "type": "proof_step_id",
+          "named": true
+        },
+        {
+          "type": "record_literal",
+          "named": true
+        },
+        {
+          "type": "record_value",
+          "named": true
+        },
+        {
+          "type": "set_filter",
+          "named": true
+        },
+        {
+          "type": "set_map",
+          "named": true
+        },
+        {
+          "type": "set_of_functions",
+          "named": true
+        },
+        {
+          "type": "set_of_records",
+          "named": true
+        },
+        {
+          "type": "step_expr_no_stutter",
+          "named": true
+        },
+        {
+          "type": "step_expr_or_stutter",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "subexpression",
+          "named": true
+        },
+        {
+          "type": "tuple_literal",
+          "named": true
+        },
+        {
+          "type": "unbounded_quantification",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "finite_set_literal",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "bound_infix_op",
+          "named": true
+        },
+        {
+          "type": "bound_nonfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_op",
+          "named": true
+        },
+        {
+          "type": "bound_postfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_prefix_op",
+          "named": true
+        },
+        {
+          "type": "bounded_quantification",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "choose",
+          "named": true
+        },
+        {
+          "type": "conj_list",
+          "named": true
+        },
+        {
+          "type": "disj_list",
+          "named": true
+        },
+        {
+          "type": "except",
+          "named": true
+        },
+        {
+          "type": "fairness",
+          "named": true
+        },
+        {
+          "type": "finite_set_literal",
+          "named": true
+        },
+        {
+          "type": "function_evaluation",
+          "named": true
+        },
+        {
+          "type": "function_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "if_then_else",
+          "named": true
+        },
+        {
+          "type": "label",
+          "named": true
+        },
+        {
+          "type": "let_in",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "parentheses",
+          "named": true
+        },
+        {
+          "type": "prefixed_op",
+          "named": true
+        },
+        {
+          "type": "prev_func_val",
+          "named": true
+        },
+        {
+          "type": "primitive_value_set",
+          "named": true
+        },
+        {
+          "type": "proof_step_id",
+          "named": true
+        },
+        {
+          "type": "record_literal",
+          "named": true
+        },
+        {
+          "type": "record_value",
+          "named": true
+        },
+        {
+          "type": "set_filter",
+          "named": true
+        },
+        {
+          "type": "set_map",
+          "named": true
+        },
+        {
+          "type": "set_of_functions",
+          "named": true
+        },
+        {
+          "type": "set_of_records",
+          "named": true
+        },
+        {
+          "type": "step_expr_no_stutter",
+          "named": true
+        },
+        {
+          "type": "step_expr_or_stutter",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "subexpression",
+          "named": true
+        },
+        {
+          "type": "tuple_literal",
+          "named": true
+        },
+        {
+          "type": "unbounded_quantification",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "forall",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "function_definition",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "bound_infix_op",
+          "named": true
+        },
+        {
+          "type": "bound_nonfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_op",
+          "named": true
+        },
+        {
+          "type": "bound_postfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_prefix_op",
+          "named": true
+        },
+        {
+          "type": "bounded_quantification",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "choose",
+          "named": true
+        },
+        {
+          "type": "conj_list",
+          "named": true
+        },
+        {
+          "type": "def_eq",
+          "named": true
+        },
+        {
+          "type": "disj_list",
+          "named": true
+        },
+        {
+          "type": "except",
+          "named": true
+        },
+        {
+          "type": "fairness",
+          "named": true
+        },
+        {
+          "type": "finite_set_literal",
+          "named": true
+        },
+        {
+          "type": "function_evaluation",
+          "named": true
+        },
+        {
+          "type": "function_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "if_then_else",
+          "named": true
+        },
+        {
+          "type": "label",
+          "named": true
+        },
+        {
+          "type": "let_in",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "parentheses",
+          "named": true
+        },
+        {
+          "type": "prefixed_op",
+          "named": true
+        },
+        {
+          "type": "prev_func_val",
+          "named": true
+        },
+        {
+          "type": "primitive_value_set",
+          "named": true
+        },
+        {
+          "type": "proof_step_id",
+          "named": true
+        },
+        {
+          "type": "quantifier_bound",
+          "named": true
+        },
+        {
+          "type": "record_literal",
+          "named": true
+        },
+        {
+          "type": "record_value",
+          "named": true
+        },
+        {
+          "type": "set_filter",
+          "named": true
+        },
+        {
+          "type": "set_map",
+          "named": true
+        },
+        {
+          "type": "set_of_functions",
+          "named": true
+        },
+        {
+          "type": "set_of_records",
+          "named": true
+        },
+        {
+          "type": "step_expr_no_stutter",
+          "named": true
+        },
+        {
+          "type": "step_expr_or_stutter",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "subexpression",
+          "named": true
+        },
+        {
+          "type": "tuple_literal",
+          "named": true
+        },
+        {
+          "type": "unbounded_quantification",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "function_evaluation",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "bound_infix_op",
+          "named": true
+        },
+        {
+          "type": "bound_nonfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_op",
+          "named": true
+        },
+        {
+          "type": "bound_postfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_prefix_op",
+          "named": true
+        },
+        {
+          "type": "bounded_quantification",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "choose",
+          "named": true
+        },
+        {
+          "type": "conj_list",
+          "named": true
+        },
+        {
+          "type": "disj_list",
+          "named": true
+        },
+        {
+          "type": "except",
+          "named": true
+        },
+        {
+          "type": "fairness",
+          "named": true
+        },
+        {
+          "type": "finite_set_literal",
+          "named": true
+        },
+        {
+          "type": "function_evaluation",
+          "named": true
+        },
+        {
+          "type": "function_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "if_then_else",
+          "named": true
+        },
+        {
+          "type": "label",
+          "named": true
+        },
+        {
+          "type": "let_in",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "parentheses",
+          "named": true
+        },
+        {
+          "type": "prefixed_op",
+          "named": true
+        },
+        {
+          "type": "prev_func_val",
+          "named": true
+        },
+        {
+          "type": "primitive_value_set",
+          "named": true
+        },
+        {
+          "type": "proof_step_id",
+          "named": true
+        },
+        {
+          "type": "record_literal",
+          "named": true
+        },
+        {
+          "type": "record_value",
+          "named": true
+        },
+        {
+          "type": "set_filter",
+          "named": true
+        },
+        {
+          "type": "set_map",
+          "named": true
+        },
+        {
+          "type": "set_of_functions",
+          "named": true
+        },
+        {
+          "type": "set_of_records",
+          "named": true
+        },
+        {
+          "type": "step_expr_no_stutter",
+          "named": true
+        },
+        {
+          "type": "step_expr_or_stutter",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "subexpression",
+          "named": true
+        },
+        {
+          "type": "tuple_literal",
+          "named": true
+        },
+        {
+          "type": "unbounded_quantification",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "function_literal",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "all_map_to",
+          "named": true
+        },
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "bound_infix_op",
+          "named": true
+        },
+        {
+          "type": "bound_nonfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_op",
+          "named": true
+        },
+        {
+          "type": "bound_postfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_prefix_op",
+          "named": true
+        },
+        {
+          "type": "bounded_quantification",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "choose",
+          "named": true
+        },
+        {
+          "type": "conj_list",
+          "named": true
+        },
+        {
+          "type": "disj_list",
+          "named": true
+        },
+        {
+          "type": "except",
+          "named": true
+        },
+        {
+          "type": "fairness",
+          "named": true
+        },
+        {
+          "type": "finite_set_literal",
+          "named": true
+        },
+        {
+          "type": "function_evaluation",
+          "named": true
+        },
+        {
+          "type": "function_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "if_then_else",
+          "named": true
+        },
+        {
+          "type": "label",
+          "named": true
+        },
+        {
+          "type": "let_in",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "parentheses",
+          "named": true
+        },
+        {
+          "type": "prefixed_op",
+          "named": true
+        },
+        {
+          "type": "prev_func_val",
+          "named": true
+        },
+        {
+          "type": "primitive_value_set",
+          "named": true
+        },
+        {
+          "type": "proof_step_id",
+          "named": true
+        },
+        {
+          "type": "quantifier_bound",
+          "named": true
+        },
+        {
+          "type": "record_literal",
+          "named": true
+        },
+        {
+          "type": "record_value",
+          "named": true
+        },
+        {
+          "type": "set_filter",
+          "named": true
+        },
+        {
+          "type": "set_map",
+          "named": true
+        },
+        {
+          "type": "set_of_functions",
+          "named": true
+        },
+        {
+          "type": "set_of_records",
+          "named": true
+        },
+        {
+          "type": "step_expr_no_stutter",
+          "named": true
+        },
+        {
+          "type": "step_expr_or_stutter",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "subexpression",
+          "named": true
+        },
+        {
+          "type": "tuple_literal",
+          "named": true
+        },
+        {
+          "type": "unbounded_quantification",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "geq",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "gets",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "gg",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "if_then_else",
+    "named": true,
+    "fields": {
+      "else": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "boolean",
+            "named": true
+          },
+          {
+            "type": "bound_infix_op",
+            "named": true
+          },
+          {
+            "type": "bound_nonfix_op",
+            "named": true
+          },
+          {
+            "type": "bound_op",
+            "named": true
+          },
+          {
+            "type": "bound_postfix_op",
+            "named": true
+          },
+          {
+            "type": "bound_prefix_op",
+            "named": true
+          },
+          {
+            "type": "bounded_quantification",
+            "named": true
+          },
+          {
+            "type": "case",
+            "named": true
+          },
+          {
+            "type": "choose",
+            "named": true
+          },
+          {
+            "type": "conj_list",
+            "named": true
+          },
+          {
+            "type": "disj_list",
+            "named": true
+          },
+          {
+            "type": "except",
+            "named": true
+          },
+          {
+            "type": "fairness",
+            "named": true
+          },
+          {
+            "type": "finite_set_literal",
+            "named": true
+          },
+          {
+            "type": "function_evaluation",
+            "named": true
+          },
+          {
+            "type": "function_literal",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "if_then_else",
+            "named": true
+          },
+          {
+            "type": "label",
+            "named": true
+          },
+          {
+            "type": "let_in",
+            "named": true
+          },
+          {
+            "type": "number",
+            "named": true
+          },
+          {
+            "type": "parentheses",
+            "named": true
+          },
+          {
+            "type": "prefixed_op",
+            "named": true
+          },
+          {
+            "type": "prev_func_val",
+            "named": true
+          },
+          {
+            "type": "primitive_value_set",
+            "named": true
+          },
+          {
+            "type": "proof_step_id",
+            "named": true
+          },
+          {
+            "type": "record_literal",
+            "named": true
+          },
+          {
+            "type": "record_value",
+            "named": true
+          },
+          {
+            "type": "set_filter",
+            "named": true
+          },
+          {
+            "type": "set_map",
+            "named": true
+          },
+          {
+            "type": "set_of_functions",
+            "named": true
+          },
+          {
+            "type": "set_of_records",
+            "named": true
+          },
+          {
+            "type": "step_expr_no_stutter",
+            "named": true
+          },
+          {
+            "type": "step_expr_or_stutter",
+            "named": true
+          },
+          {
+            "type": "string",
+            "named": true
+          },
+          {
+            "type": "subexpression",
+            "named": true
+          },
+          {
+            "type": "tuple_literal",
+            "named": true
+          },
+          {
+            "type": "unbounded_quantification",
+            "named": true
+          }
+        ]
+      },
+      "if": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "boolean",
+            "named": true
+          },
+          {
+            "type": "bound_infix_op",
+            "named": true
+          },
+          {
+            "type": "bound_nonfix_op",
+            "named": true
+          },
+          {
+            "type": "bound_op",
+            "named": true
+          },
+          {
+            "type": "bound_postfix_op",
+            "named": true
+          },
+          {
+            "type": "bound_prefix_op",
+            "named": true
+          },
+          {
+            "type": "bounded_quantification",
+            "named": true
+          },
+          {
+            "type": "case",
+            "named": true
+          },
+          {
+            "type": "choose",
+            "named": true
+          },
+          {
+            "type": "conj_list",
+            "named": true
+          },
+          {
+            "type": "disj_list",
+            "named": true
+          },
+          {
+            "type": "except",
+            "named": true
+          },
+          {
+            "type": "fairness",
+            "named": true
+          },
+          {
+            "type": "finite_set_literal",
+            "named": true
+          },
+          {
+            "type": "function_evaluation",
+            "named": true
+          },
+          {
+            "type": "function_literal",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "if_then_else",
+            "named": true
+          },
+          {
+            "type": "label",
+            "named": true
+          },
+          {
+            "type": "let_in",
+            "named": true
+          },
+          {
+            "type": "number",
+            "named": true
+          },
+          {
+            "type": "parentheses",
+            "named": true
+          },
+          {
+            "type": "prefixed_op",
+            "named": true
+          },
+          {
+            "type": "prev_func_val",
+            "named": true
+          },
+          {
+            "type": "primitive_value_set",
+            "named": true
+          },
+          {
+            "type": "proof_step_id",
+            "named": true
+          },
+          {
+            "type": "record_literal",
+            "named": true
+          },
+          {
+            "type": "record_value",
+            "named": true
+          },
+          {
+            "type": "set_filter",
+            "named": true
+          },
+          {
+            "type": "set_map",
+            "named": true
+          },
+          {
+            "type": "set_of_functions",
+            "named": true
+          },
+          {
+            "type": "set_of_records",
+            "named": true
+          },
+          {
+            "type": "step_expr_no_stutter",
+            "named": true
+          },
+          {
+            "type": "step_expr_or_stutter",
+            "named": true
+          },
+          {
+            "type": "string",
+            "named": true
+          },
+          {
+            "type": "subexpression",
+            "named": true
+          },
+          {
+            "type": "tuple_literal",
+            "named": true
+          },
+          {
+            "type": "unbounded_quantification",
+            "named": true
+          }
+        ]
+      },
+      "then": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "boolean",
+            "named": true
+          },
+          {
+            "type": "bound_infix_op",
+            "named": true
+          },
+          {
+            "type": "bound_nonfix_op",
+            "named": true
+          },
+          {
+            "type": "bound_op",
+            "named": true
+          },
+          {
+            "type": "bound_postfix_op",
+            "named": true
+          },
+          {
+            "type": "bound_prefix_op",
+            "named": true
+          },
+          {
+            "type": "bounded_quantification",
+            "named": true
+          },
+          {
+            "type": "case",
+            "named": true
+          },
+          {
+            "type": "choose",
+            "named": true
+          },
+          {
+            "type": "conj_list",
+            "named": true
+          },
+          {
+            "type": "disj_list",
+            "named": true
+          },
+          {
+            "type": "except",
+            "named": true
+          },
+          {
+            "type": "fairness",
+            "named": true
+          },
+          {
+            "type": "finite_set_literal",
+            "named": true
+          },
+          {
+            "type": "function_evaluation",
+            "named": true
+          },
+          {
+            "type": "function_literal",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "if_then_else",
+            "named": true
+          },
+          {
+            "type": "label",
+            "named": true
+          },
+          {
+            "type": "let_in",
+            "named": true
+          },
+          {
+            "type": "number",
+            "named": true
+          },
+          {
+            "type": "parentheses",
+            "named": true
+          },
+          {
+            "type": "prefixed_op",
+            "named": true
+          },
+          {
+            "type": "prev_func_val",
+            "named": true
+          },
+          {
+            "type": "primitive_value_set",
+            "named": true
+          },
+          {
+            "type": "proof_step_id",
+            "named": true
+          },
+          {
+            "type": "record_literal",
+            "named": true
+          },
+          {
+            "type": "record_value",
+            "named": true
+          },
+          {
+            "type": "set_filter",
+            "named": true
+          },
+          {
+            "type": "set_map",
+            "named": true
+          },
+          {
+            "type": "set_of_functions",
+            "named": true
+          },
+          {
+            "type": "set_of_records",
+            "named": true
+          },
+          {
+            "type": "step_expr_no_stutter",
+            "named": true
+          },
+          {
+            "type": "step_expr_or_stutter",
+            "named": true
+          },
+          {
+            "type": "string",
+            "named": true
+          },
+          {
+            "type": "subexpression",
+            "named": true
+          },
+          {
+            "type": "tuple_literal",
+            "named": true
+          },
+          {
+            "type": "unbounded_quantification",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "iff",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "implies",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "in",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "infix_op_symbol",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "amp",
+          "named": true
+        },
+        {
+          "type": "ampamp",
+          "named": true
+        },
+        {
+          "type": "approx",
+          "named": true
+        },
+        {
+          "type": "assign",
+          "named": true
+        },
+        {
+          "type": "asymp",
+          "named": true
+        },
+        {
+          "type": "bigcirc",
+          "named": true
+        },
+        {
+          "type": "bnf_rule",
+          "named": true
+        },
+        {
+          "type": "bullet",
+          "named": true
+        },
+        {
+          "type": "cap",
+          "named": true
+        },
+        {
+          "type": "cdot",
+          "named": true
+        },
+        {
+          "type": "circ",
+          "named": true
+        },
+        {
+          "type": "compose",
+          "named": true
+        },
+        {
+          "type": "cong",
+          "named": true
+        },
+        {
+          "type": "cup",
+          "named": true
+        },
+        {
+          "type": "div",
+          "named": true
+        },
+        {
+          "type": "dol",
+          "named": true
+        },
+        {
+          "type": "doldol",
+          "named": true
+        },
+        {
+          "type": "doteq",
+          "named": true
+        },
+        {
+          "type": "dots_2",
+          "named": true
+        },
+        {
+          "type": "dots_3",
+          "named": true
+        },
+        {
+          "type": "eq",
+          "named": true
+        },
+        {
+          "type": "equiv",
+          "named": true
+        },
+        {
+          "type": "excl",
+          "named": true
+        },
+        {
+          "type": "geq",
+          "named": true
+        },
+        {
+          "type": "gg",
+          "named": true
+        },
+        {
+          "type": "gt",
+          "named": true
+        },
+        {
+          "type": "hashhash",
+          "named": true
+        },
+        {
+          "type": "iff",
+          "named": true
+        },
+        {
+          "type": "implies",
+          "named": true
+        },
+        {
+          "type": "in",
+          "named": true
+        },
+        {
+          "type": "land",
+          "named": true
+        },
+        {
+          "type": "ld_ttile",
+          "named": true
+        },
+        {
+          "type": "leads_to",
+          "named": true
+        },
+        {
+          "type": "leq",
+          "named": true
+        },
+        {
+          "type": "ll",
+          "named": true
+        },
+        {
+          "type": "lor",
+          "named": true
+        },
+        {
+          "type": "ls_ttile",
+          "named": true
+        },
+        {
+          "type": "lt",
+          "named": true
+        },
+        {
+          "type": "map_from",
+          "named": true
+        },
+        {
+          "type": "map_to",
+          "named": true
+        },
+        {
+          "type": "minus",
+          "named": true
+        },
+        {
+          "type": "minusminus",
+          "named": true
+        },
+        {
+          "type": "mod",
+          "named": true
+        },
+        {
+          "type": "modmod",
+          "named": true
+        },
+        {
+          "type": "mul",
+          "named": true
+        },
+        {
+          "type": "mulmul",
+          "named": true
+        },
+        {
+          "type": "neq",
+          "named": true
+        },
+        {
+          "type": "notin",
+          "named": true
+        },
+        {
+          "type": "odot",
+          "named": true
+        },
+        {
+          "type": "ominus",
+          "named": true
+        },
+        {
+          "type": "oplus",
+          "named": true
+        },
+        {
+          "type": "oslash",
+          "named": true
+        },
+        {
+          "type": "otimes",
+          "named": true
+        },
+        {
+          "type": "plus",
+          "named": true
+        },
+        {
+          "type": "plus_arrow",
+          "named": true
+        },
+        {
+          "type": "plusplus",
+          "named": true
+        },
+        {
+          "type": "pow",
+          "named": true
+        },
+        {
+          "type": "powpow",
+          "named": true
+        },
+        {
+          "type": "prec",
+          "named": true
+        },
+        {
+          "type": "preceq",
+          "named": true
+        },
+        {
+          "type": "qq",
+          "named": true
+        },
+        {
+          "type": "rd_ttile",
+          "named": true
+        },
+        {
+          "type": "rs_ttile",
+          "named": true
+        },
+        {
+          "type": "setminus",
+          "named": true
+        },
+        {
+          "type": "sim",
+          "named": true
+        },
+        {
+          "type": "simeq",
+          "named": true
+        },
+        {
+          "type": "slash",
+          "named": true
+        },
+        {
+          "type": "slashslash",
+          "named": true
+        },
+        {
+          "type": "sqcap",
+          "named": true
+        },
+        {
+          "type": "sqcup",
+          "named": true
+        },
+        {
+          "type": "sqsubset",
+          "named": true
+        },
+        {
+          "type": "sqsubseteq",
+          "named": true
+        },
+        {
+          "type": "sqsupset",
+          "named": true
+        },
+        {
+          "type": "sqsupseteq",
+          "named": true
+        },
+        {
+          "type": "star",
+          "named": true
+        },
+        {
+          "type": "succ",
+          "named": true
+        },
+        {
+          "type": "succeq",
+          "named": true
+        },
+        {
+          "type": "uplus",
+          "named": true
+        },
+        {
+          "type": "vert",
+          "named": true
+        },
+        {
+          "type": "vertvert",
+          "named": true
+        },
+        {
+          "type": "wr",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "inner_assume_prove",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "assume_prove",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "label_as",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "instance",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "substitution",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "label",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "bound_infix_op",
+          "named": true
+        },
+        {
+          "type": "bound_nonfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_op",
+          "named": true
+        },
+        {
+          "type": "bound_postfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_prefix_op",
+          "named": true
+        },
+        {
+          "type": "bounded_quantification",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "choose",
+          "named": true
+        },
+        {
+          "type": "conj_list",
+          "named": true
+        },
+        {
+          "type": "disj_list",
+          "named": true
+        },
+        {
+          "type": "except",
+          "named": true
+        },
+        {
+          "type": "fairness",
+          "named": true
+        },
+        {
+          "type": "finite_set_literal",
+          "named": true
+        },
+        {
+          "type": "function_evaluation",
+          "named": true
+        },
+        {
+          "type": "function_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "if_then_else",
+          "named": true
+        },
+        {
+          "type": "label",
+          "named": true
+        },
+        {
+          "type": "label_as",
+          "named": true
+        },
+        {
+          "type": "let_in",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "parentheses",
+          "named": true
+        },
+        {
+          "type": "prefixed_op",
+          "named": true
+        },
+        {
+          "type": "prev_func_val",
+          "named": true
+        },
+        {
+          "type": "primitive_value_set",
+          "named": true
+        },
+        {
+          "type": "proof_step_id",
+          "named": true
+        },
+        {
+          "type": "record_literal",
+          "named": true
+        },
+        {
+          "type": "record_value",
+          "named": true
+        },
+        {
+          "type": "set_filter",
+          "named": true
+        },
+        {
+          "type": "set_map",
+          "named": true
+        },
+        {
+          "type": "set_of_functions",
+          "named": true
+        },
+        {
+          "type": "set_of_records",
+          "named": true
+        },
+        {
+          "type": "step_expr_no_stutter",
+          "named": true
+        },
+        {
+          "type": "step_expr_or_stutter",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "subexpression",
+          "named": true
+        },
+        {
+          "type": "tuple_literal",
+          "named": true
+        },
+        {
+          "type": "unbounded_quantification",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "label_as",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "lambda",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "bound_infix_op",
+          "named": true
+        },
+        {
+          "type": "bound_nonfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_op",
+          "named": true
+        },
+        {
+          "type": "bound_postfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_prefix_op",
+          "named": true
+        },
+        {
+          "type": "bounded_quantification",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "choose",
+          "named": true
+        },
+        {
+          "type": "conj_list",
+          "named": true
+        },
+        {
+          "type": "disj_list",
+          "named": true
+        },
+        {
+          "type": "except",
+          "named": true
+        },
+        {
+          "type": "fairness",
+          "named": true
+        },
+        {
+          "type": "finite_set_literal",
+          "named": true
+        },
+        {
+          "type": "function_evaluation",
+          "named": true
+        },
+        {
+          "type": "function_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "if_then_else",
+          "named": true
+        },
+        {
+          "type": "label",
+          "named": true
+        },
+        {
+          "type": "let_in",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "parentheses",
+          "named": true
+        },
+        {
+          "type": "prefixed_op",
+          "named": true
+        },
+        {
+          "type": "prev_func_val",
+          "named": true
+        },
+        {
+          "type": "primitive_value_set",
+          "named": true
+        },
+        {
+          "type": "proof_step_id",
+          "named": true
+        },
+        {
+          "type": "record_literal",
+          "named": true
+        },
+        {
+          "type": "record_value",
+          "named": true
+        },
+        {
+          "type": "set_filter",
+          "named": true
+        },
+        {
+          "type": "set_map",
+          "named": true
+        },
+        {
+          "type": "set_of_functions",
+          "named": true
+        },
+        {
+          "type": "set_of_records",
+          "named": true
+        },
+        {
+          "type": "step_expr_no_stutter",
+          "named": true
+        },
+        {
+          "type": "step_expr_or_stutter",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "subexpression",
+          "named": true
+        },
+        {
+          "type": "tuple_literal",
+          "named": true
+        },
+        {
+          "type": "unbounded_quantification",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "land",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "langle_bracket",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "ld_ttile",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "leads_to",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "leq",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "let_in",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "bound_infix_op",
+          "named": true
+        },
+        {
+          "type": "bound_nonfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_op",
+          "named": true
+        },
+        {
+          "type": "bound_postfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_prefix_op",
+          "named": true
+        },
+        {
+          "type": "bounded_quantification",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "choose",
+          "named": true
+        },
+        {
+          "type": "conj_list",
+          "named": true
+        },
+        {
+          "type": "disj_list",
+          "named": true
+        },
+        {
+          "type": "except",
+          "named": true
+        },
+        {
+          "type": "fairness",
+          "named": true
+        },
+        {
+          "type": "finite_set_literal",
+          "named": true
+        },
+        {
+          "type": "function_definition",
+          "named": true
+        },
+        {
+          "type": "function_evaluation",
+          "named": true
+        },
+        {
+          "type": "function_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "if_then_else",
+          "named": true
+        },
+        {
+          "type": "label",
+          "named": true
+        },
+        {
+          "type": "let_in",
+          "named": true
+        },
+        {
+          "type": "module_definition",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "operator_definition",
+          "named": true
+        },
+        {
+          "type": "parentheses",
+          "named": true
+        },
+        {
+          "type": "prefixed_op",
+          "named": true
+        },
+        {
+          "type": "prev_func_val",
+          "named": true
+        },
+        {
+          "type": "primitive_value_set",
+          "named": true
+        },
+        {
+          "type": "proof_step_id",
+          "named": true
+        },
+        {
+          "type": "record_literal",
+          "named": true
+        },
+        {
+          "type": "record_value",
+          "named": true
+        },
+        {
+          "type": "recursive_operator_declaration",
+          "named": true
+        },
+        {
+          "type": "set_filter",
+          "named": true
+        },
+        {
+          "type": "set_map",
+          "named": true
+        },
+        {
+          "type": "set_of_functions",
+          "named": true
+        },
+        {
+          "type": "set_of_records",
+          "named": true
+        },
+        {
+          "type": "step_expr_no_stutter",
+          "named": true
+        },
+        {
+          "type": "step_expr_or_stutter",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "subexpression",
+          "named": true
+        },
+        {
+          "type": "tuple_literal",
+          "named": true
+        },
+        {
+          "type": "unbounded_quantification",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "level",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "ll",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "lnot",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "lor",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "ls_ttile",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "maps_to",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "minus",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "module",
+    "named": true,
+    "fields": {
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "extends",
+          "named": true
+        },
+        {
+          "type": "unit",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "module_definition",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "def_eq",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "instance",
+          "named": true
+        },
+        {
+          "type": "operator_declaration",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "negative",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "neq",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "new",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "bound_infix_op",
+          "named": true
+        },
+        {
+          "type": "bound_nonfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_op",
+          "named": true
+        },
+        {
+          "type": "bound_postfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_prefix_op",
+          "named": true
+        },
+        {
+          "type": "bounded_quantification",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "choose",
+          "named": true
+        },
+        {
+          "type": "conj_list",
+          "named": true
+        },
+        {
+          "type": "disj_list",
+          "named": true
+        },
+        {
+          "type": "except",
+          "named": true
+        },
+        {
+          "type": "fairness",
+          "named": true
+        },
+        {
+          "type": "finite_set_literal",
+          "named": true
+        },
+        {
+          "type": "function_evaluation",
+          "named": true
+        },
+        {
+          "type": "function_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "if_then_else",
+          "named": true
+        },
+        {
+          "type": "label",
+          "named": true
+        },
+        {
+          "type": "let_in",
+          "named": true
+        },
+        {
+          "type": "level",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "operator_declaration",
+          "named": true
+        },
+        {
+          "type": "parentheses",
+          "named": true
+        },
+        {
+          "type": "prefixed_op",
+          "named": true
+        },
+        {
+          "type": "prev_func_val",
+          "named": true
+        },
+        {
+          "type": "primitive_value_set",
+          "named": true
+        },
+        {
+          "type": "proof_step_id",
+          "named": true
+        },
+        {
+          "type": "record_literal",
+          "named": true
+        },
+        {
+          "type": "record_value",
+          "named": true
+        },
+        {
+          "type": "set_filter",
+          "named": true
+        },
+        {
+          "type": "set_in",
+          "named": true
+        },
+        {
+          "type": "set_map",
+          "named": true
+        },
+        {
+          "type": "set_of_functions",
+          "named": true
+        },
+        {
+          "type": "set_of_records",
+          "named": true
+        },
+        {
+          "type": "step_expr_no_stutter",
+          "named": true
+        },
+        {
+          "type": "step_expr_or_stutter",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "subexpression",
+          "named": true
+        },
+        {
+          "type": "tuple_literal",
+          "named": true
+        },
+        {
+          "type": "unbounded_quantification",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "non_terminal_proof",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "proof_step",
+          "named": true
+        },
+        {
+          "type": "qed_step",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "notin",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "number",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "binary_number",
+          "named": true
+        },
+        {
+          "type": "hex_number",
+          "named": true
+        },
+        {
+          "type": "nat_number",
+          "named": true
+        },
+        {
+          "type": "octal_number",
+          "named": true
+        },
+        {
+          "type": "real_number",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "odot",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "ominus",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "op_or_expr",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "bound_infix_op",
+          "named": true
+        },
+        {
+          "type": "bound_nonfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_op",
+          "named": true
+        },
+        {
+          "type": "bound_postfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_prefix_op",
+          "named": true
+        },
+        {
+          "type": "bounded_quantification",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "choose",
+          "named": true
+        },
+        {
+          "type": "conj_list",
+          "named": true
+        },
+        {
+          "type": "disj_list",
+          "named": true
+        },
+        {
+          "type": "except",
+          "named": true
+        },
+        {
+          "type": "fairness",
+          "named": true
+        },
+        {
+          "type": "finite_set_literal",
+          "named": true
+        },
+        {
+          "type": "function_evaluation",
+          "named": true
+        },
+        {
+          "type": "function_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "if_then_else",
+          "named": true
+        },
+        {
+          "type": "infix_op_symbol",
+          "named": true
+        },
+        {
+          "type": "label",
+          "named": true
+        },
+        {
+          "type": "lambda",
+          "named": true
+        },
+        {
+          "type": "let_in",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "parentheses",
+          "named": true
+        },
+        {
+          "type": "postfix_op_symbol",
+          "named": true
+        },
+        {
+          "type": "prefixed_op",
+          "named": true
+        },
+        {
+          "type": "prev_func_val",
+          "named": true
+        },
+        {
+          "type": "primitive_value_set",
+          "named": true
+        },
+        {
+          "type": "proof_step_id",
+          "named": true
+        },
+        {
+          "type": "record_literal",
+          "named": true
+        },
+        {
+          "type": "record_value",
+          "named": true
+        },
+        {
+          "type": "set_filter",
+          "named": true
+        },
+        {
+          "type": "set_map",
+          "named": true
+        },
+        {
+          "type": "set_of_functions",
+          "named": true
+        },
+        {
+          "type": "set_of_records",
+          "named": true
+        },
+        {
+          "type": "standalone_prefix_op_symbol",
+          "named": true
+        },
+        {
+          "type": "step_expr_no_stutter",
+          "named": true
+        },
+        {
+          "type": "step_expr_or_stutter",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "subexpression",
+          "named": true
+        },
+        {
+          "type": "tuple_literal",
+          "named": true
+        },
+        {
+          "type": "unbounded_quantification",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "operator_args",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "op_or_expr",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "operator_declaration",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "infix_op_symbol",
+          "named": true
+        },
+        {
+          "type": "placeholder",
+          "named": true
+        },
+        {
+          "type": "postfix_op_symbol",
+          "named": true
+        },
+        {
+          "type": "standalone_prefix_op_symbol",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "operator_definition",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "bound_infix_op",
+          "named": true
+        },
+        {
+          "type": "bound_nonfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_op",
+          "named": true
+        },
+        {
+          "type": "bound_postfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_prefix_op",
+          "named": true
+        },
+        {
+          "type": "bounded_quantification",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "choose",
+          "named": true
+        },
+        {
+          "type": "conj_list",
+          "named": true
+        },
+        {
+          "type": "def_eq",
+          "named": true
+        },
+        {
+          "type": "disj_list",
+          "named": true
+        },
+        {
+          "type": "except",
+          "named": true
+        },
+        {
+          "type": "fairness",
+          "named": true
+        },
+        {
+          "type": "finite_set_literal",
+          "named": true
+        },
+        {
+          "type": "function_evaluation",
+          "named": true
+        },
+        {
+          "type": "function_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "if_then_else",
+          "named": true
+        },
+        {
+          "type": "infix_op_symbol",
+          "named": true
+        },
+        {
+          "type": "label",
+          "named": true
+        },
+        {
+          "type": "let_in",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "operator_declaration",
+          "named": true
+        },
+        {
+          "type": "parentheses",
+          "named": true
+        },
+        {
+          "type": "postfix_op_symbol",
+          "named": true
+        },
+        {
+          "type": "prefixed_op",
+          "named": true
+        },
+        {
+          "type": "prev_func_val",
+          "named": true
+        },
+        {
+          "type": "primitive_value_set",
+          "named": true
+        },
+        {
+          "type": "proof_step_id",
+          "named": true
+        },
+        {
+          "type": "record_literal",
+          "named": true
+        },
+        {
+          "type": "record_value",
+          "named": true
+        },
+        {
+          "type": "set_filter",
+          "named": true
+        },
+        {
+          "type": "set_map",
+          "named": true
+        },
+        {
+          "type": "set_of_functions",
+          "named": true
+        },
+        {
+          "type": "set_of_records",
+          "named": true
+        },
+        {
+          "type": "standalone_prefix_op_symbol",
+          "named": true
+        },
+        {
+          "type": "step_expr_no_stutter",
+          "named": true
+        },
+        {
+          "type": "step_expr_or_stutter",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "subexpression",
+          "named": true
+        },
+        {
+          "type": "tuple_literal",
+          "named": true
+        },
+        {
+          "type": "unbounded_quantification",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "oplus",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "oslash",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "other_arm",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "bound_infix_op",
+          "named": true
+        },
+        {
+          "type": "bound_nonfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_op",
+          "named": true
+        },
+        {
+          "type": "bound_postfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_prefix_op",
+          "named": true
+        },
+        {
+          "type": "bounded_quantification",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "case_arrow",
+          "named": true
+        },
+        {
+          "type": "choose",
+          "named": true
+        },
+        {
+          "type": "conj_list",
+          "named": true
+        },
+        {
+          "type": "disj_list",
+          "named": true
+        },
+        {
+          "type": "except",
+          "named": true
+        },
+        {
+          "type": "fairness",
+          "named": true
+        },
+        {
+          "type": "finite_set_literal",
+          "named": true
+        },
+        {
+          "type": "function_evaluation",
+          "named": true
+        },
+        {
+          "type": "function_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "if_then_else",
+          "named": true
+        },
+        {
+          "type": "label",
+          "named": true
+        },
+        {
+          "type": "let_in",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "parentheses",
+          "named": true
+        },
+        {
+          "type": "prefixed_op",
+          "named": true
+        },
+        {
+          "type": "prev_func_val",
+          "named": true
+        },
+        {
+          "type": "primitive_value_set",
+          "named": true
+        },
+        {
+          "type": "proof_step_id",
+          "named": true
+        },
+        {
+          "type": "record_literal",
+          "named": true
+        },
+        {
+          "type": "record_value",
+          "named": true
+        },
+        {
+          "type": "set_filter",
+          "named": true
+        },
+        {
+          "type": "set_map",
+          "named": true
+        },
+        {
+          "type": "set_of_functions",
+          "named": true
+        },
+        {
+          "type": "set_of_records",
+          "named": true
+        },
+        {
+          "type": "step_expr_no_stutter",
+          "named": true
+        },
+        {
+          "type": "step_expr_or_stutter",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "subexpression",
+          "named": true
+        },
+        {
+          "type": "tuple_literal",
+          "named": true
+        },
+        {
+          "type": "unbounded_quantification",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "otimes",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "parentheses",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "bound_infix_op",
+          "named": true
+        },
+        {
+          "type": "bound_nonfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_op",
+          "named": true
+        },
+        {
+          "type": "bound_postfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_prefix_op",
+          "named": true
+        },
+        {
+          "type": "bounded_quantification",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "choose",
+          "named": true
+        },
+        {
+          "type": "conj_list",
+          "named": true
+        },
+        {
+          "type": "disj_list",
+          "named": true
+        },
+        {
+          "type": "except",
+          "named": true
+        },
+        {
+          "type": "fairness",
+          "named": true
+        },
+        {
+          "type": "finite_set_literal",
+          "named": true
+        },
+        {
+          "type": "function_evaluation",
+          "named": true
+        },
+        {
+          "type": "function_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "if_then_else",
+          "named": true
+        },
+        {
+          "type": "label",
+          "named": true
+        },
+        {
+          "type": "let_in",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "parentheses",
+          "named": true
+        },
+        {
+          "type": "prefixed_op",
+          "named": true
+        },
+        {
+          "type": "prev_func_val",
+          "named": true
+        },
+        {
+          "type": "primitive_value_set",
+          "named": true
+        },
+        {
+          "type": "proof_step_id",
+          "named": true
+        },
+        {
+          "type": "record_literal",
+          "named": true
+        },
+        {
+          "type": "record_value",
+          "named": true
+        },
+        {
+          "type": "set_filter",
+          "named": true
+        },
+        {
+          "type": "set_map",
+          "named": true
+        },
+        {
+          "type": "set_of_functions",
+          "named": true
+        },
+        {
+          "type": "set_of_records",
+          "named": true
+        },
+        {
+          "type": "step_expr_no_stutter",
+          "named": true
+        },
+        {
+          "type": "step_expr_or_stutter",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "subexpression",
+          "named": true
+        },
+        {
+          "type": "tuple_literal",
+          "named": true
+        },
+        {
+          "type": "unbounded_quantification",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "plus_arrow",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "postfix_op_symbol",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "asterisk",
+          "named": true
+        },
+        {
+          "type": "prime",
+          "named": true
+        },
+        {
+          "type": "sup_hash",
+          "named": true
+        },
+        {
+          "type": "sup_plus",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "powerset",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "prec",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "preceq",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "prefixed_op",
+    "named": true,
+    "fields": {
+      "op": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "bound_nonfix_op",
+            "named": true
+          },
+          {
+            "type": "bound_op",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      },
+      "prefix": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "subexpr_prefix",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "prev_func_val",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "primitive_value_set",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "proof",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "non_terminal_proof",
+          "named": true
+        },
+        {
+          "type": "terminal_proof",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "proof_step",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "assume_prove",
+          "named": true
+        },
+        {
+          "type": "begin_proof_step_token",
+          "named": true
+        },
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "bound_infix_op",
+          "named": true
+        },
+        {
+          "type": "bound_nonfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_op",
+          "named": true
+        },
+        {
+          "type": "bound_or_identifier_list",
+          "named": true
+        },
+        {
+          "type": "bound_postfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_prefix_op",
+          "named": true
+        },
+        {
+          "type": "bounded_quantification",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "choose",
+          "named": true
+        },
+        {
+          "type": "conj_list",
+          "named": true
+        },
+        {
+          "type": "disj_list",
+          "named": true
+        },
+        {
+          "type": "except",
+          "named": true
+        },
+        {
+          "type": "fairness",
+          "named": true
+        },
+        {
+          "type": "finite_set_literal",
+          "named": true
+        },
+        {
+          "type": "function_definition",
+          "named": true
+        },
+        {
+          "type": "function_evaluation",
+          "named": true
+        },
+        {
+          "type": "function_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "if_then_else",
+          "named": true
+        },
+        {
+          "type": "instance",
+          "named": true
+        },
+        {
+          "type": "label",
+          "named": true
+        },
+        {
+          "type": "let_in",
+          "named": true
+        },
+        {
+          "type": "module_definition",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "operator_definition",
+          "named": true
+        },
+        {
+          "type": "parentheses",
+          "named": true
+        },
+        {
+          "type": "prefixed_op",
+          "named": true
+        },
+        {
+          "type": "prev_func_val",
+          "named": true
+        },
+        {
+          "type": "primitive_value_set",
+          "named": true
+        },
+        {
+          "type": "proof",
+          "named": true
+        },
+        {
+          "type": "proof_step_id",
+          "named": true
+        },
+        {
+          "type": "record_literal",
+          "named": true
+        },
+        {
+          "type": "record_value",
+          "named": true
+        },
+        {
+          "type": "set_filter",
+          "named": true
+        },
+        {
+          "type": "set_map",
+          "named": true
+        },
+        {
+          "type": "set_of_functions",
+          "named": true
+        },
+        {
+          "type": "set_of_records",
+          "named": true
+        },
+        {
+          "type": "step_expr_no_stutter",
+          "named": true
+        },
+        {
+          "type": "step_expr_or_stutter",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "subexpression",
+          "named": true
+        },
+        {
+          "type": "tuple_literal",
+          "named": true
+        },
+        {
+          "type": "unbounded_quantification",
+          "named": true
+        },
+        {
+          "type": "use_or_hide",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "propto",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "qed_step",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "begin_proof_step_token",
+          "named": true
+        },
+        {
+          "type": "proof",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "qq",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "quantifier_bound",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "bound_infix_op",
+          "named": true
+        },
+        {
+          "type": "bound_nonfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_op",
+          "named": true
+        },
+        {
+          "type": "bound_postfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_prefix_op",
+          "named": true
+        },
+        {
+          "type": "bounded_quantification",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "choose",
+          "named": true
+        },
+        {
+          "type": "conj_list",
+          "named": true
+        },
+        {
+          "type": "disj_list",
+          "named": true
+        },
+        {
+          "type": "except",
+          "named": true
+        },
+        {
+          "type": "fairness",
+          "named": true
+        },
+        {
+          "type": "finite_set_literal",
+          "named": true
+        },
+        {
+          "type": "function_evaluation",
+          "named": true
+        },
+        {
+          "type": "function_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "if_then_else",
+          "named": true
+        },
+        {
+          "type": "label",
+          "named": true
+        },
+        {
+          "type": "let_in",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "parentheses",
+          "named": true
+        },
+        {
+          "type": "prefixed_op",
+          "named": true
+        },
+        {
+          "type": "prev_func_val",
+          "named": true
+        },
+        {
+          "type": "primitive_value_set",
+          "named": true
+        },
+        {
+          "type": "proof_step_id",
+          "named": true
+        },
+        {
+          "type": "record_literal",
+          "named": true
+        },
+        {
+          "type": "record_value",
+          "named": true
+        },
+        {
+          "type": "set_filter",
+          "named": true
+        },
+        {
+          "type": "set_in",
+          "named": true
+        },
+        {
+          "type": "set_map",
+          "named": true
+        },
+        {
+          "type": "set_of_functions",
+          "named": true
+        },
+        {
+          "type": "set_of_records",
+          "named": true
+        },
+        {
+          "type": "step_expr_no_stutter",
+          "named": true
+        },
+        {
+          "type": "step_expr_or_stutter",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "subexpression",
+          "named": true
+        },
+        {
+          "type": "tuple_literal",
+          "named": true
+        },
+        {
+          "type": "tuple_of_identifiers",
+          "named": true
+        },
+        {
+          "type": "unbounded_quantification",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "rangle_bracket",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "rd_ttile",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "record_literal",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "all_map_to",
+          "named": true
+        },
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "bound_infix_op",
+          "named": true
+        },
+        {
+          "type": "bound_nonfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_op",
+          "named": true
+        },
+        {
+          "type": "bound_postfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_prefix_op",
+          "named": true
+        },
+        {
+          "type": "bounded_quantification",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "choose",
+          "named": true
+        },
+        {
+          "type": "conj_list",
+          "named": true
+        },
+        {
+          "type": "disj_list",
+          "named": true
+        },
+        {
+          "type": "except",
+          "named": true
+        },
+        {
+          "type": "fairness",
+          "named": true
+        },
+        {
+          "type": "finite_set_literal",
+          "named": true
+        },
+        {
+          "type": "function_evaluation",
+          "named": true
+        },
+        {
+          "type": "function_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "if_then_else",
+          "named": true
+        },
+        {
+          "type": "label",
+          "named": true
+        },
+        {
+          "type": "let_in",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "parentheses",
+          "named": true
+        },
+        {
+          "type": "prefixed_op",
+          "named": true
+        },
+        {
+          "type": "prev_func_val",
+          "named": true
+        },
+        {
+          "type": "primitive_value_set",
+          "named": true
+        },
+        {
+          "type": "proof_step_id",
+          "named": true
+        },
+        {
+          "type": "record_literal",
+          "named": true
+        },
+        {
+          "type": "record_value",
+          "named": true
+        },
+        {
+          "type": "set_filter",
+          "named": true
+        },
+        {
+          "type": "set_map",
+          "named": true
+        },
+        {
+          "type": "set_of_functions",
+          "named": true
+        },
+        {
+          "type": "set_of_records",
+          "named": true
+        },
+        {
+          "type": "step_expr_no_stutter",
+          "named": true
+        },
+        {
+          "type": "step_expr_or_stutter",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "subexpression",
+          "named": true
+        },
+        {
+          "type": "tuple_literal",
+          "named": true
+        },
+        {
+          "type": "unbounded_quantification",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "record_value",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "bound_infix_op",
+          "named": true
+        },
+        {
+          "type": "bound_nonfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_op",
+          "named": true
+        },
+        {
+          "type": "bound_postfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_prefix_op",
+          "named": true
+        },
+        {
+          "type": "bounded_quantification",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "choose",
+          "named": true
+        },
+        {
+          "type": "conj_list",
+          "named": true
+        },
+        {
+          "type": "disj_list",
+          "named": true
+        },
+        {
+          "type": "except",
+          "named": true
+        },
+        {
+          "type": "fairness",
+          "named": true
+        },
+        {
+          "type": "finite_set_literal",
+          "named": true
+        },
+        {
+          "type": "function_evaluation",
+          "named": true
+        },
+        {
+          "type": "function_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "if_then_else",
+          "named": true
+        },
+        {
+          "type": "label",
+          "named": true
+        },
+        {
+          "type": "let_in",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "parentheses",
+          "named": true
+        },
+        {
+          "type": "prefixed_op",
+          "named": true
+        },
+        {
+          "type": "prev_func_val",
+          "named": true
+        },
+        {
+          "type": "primitive_value_set",
+          "named": true
+        },
+        {
+          "type": "proof_step_id",
+          "named": true
+        },
+        {
+          "type": "record_literal",
+          "named": true
+        },
+        {
+          "type": "record_value",
+          "named": true
+        },
+        {
+          "type": "set_filter",
+          "named": true
+        },
+        {
+          "type": "set_map",
+          "named": true
+        },
+        {
+          "type": "set_of_functions",
+          "named": true
+        },
+        {
+          "type": "set_of_records",
+          "named": true
+        },
+        {
+          "type": "step_expr_no_stutter",
+          "named": true
+        },
+        {
+          "type": "step_expr_or_stutter",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "subexpression",
+          "named": true
+        },
+        {
+          "type": "tuple_literal",
+          "named": true
+        },
+        {
+          "type": "unbounded_quantification",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "recursive_operator_declaration",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "operator_declaration",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "rs_ttile",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "set_filter",
+    "named": true,
+    "fields": {
+      "filter": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "boolean",
+            "named": true
+          },
+          {
+            "type": "bound_infix_op",
+            "named": true
+          },
+          {
+            "type": "bound_nonfix_op",
+            "named": true
+          },
+          {
+            "type": "bound_op",
+            "named": true
+          },
+          {
+            "type": "bound_postfix_op",
+            "named": true
+          },
+          {
+            "type": "bound_prefix_op",
+            "named": true
+          },
+          {
+            "type": "bounded_quantification",
+            "named": true
+          },
+          {
+            "type": "case",
+            "named": true
+          },
+          {
+            "type": "choose",
+            "named": true
+          },
+          {
+            "type": "conj_list",
+            "named": true
+          },
+          {
+            "type": "disj_list",
+            "named": true
+          },
+          {
+            "type": "except",
+            "named": true
+          },
+          {
+            "type": "fairness",
+            "named": true
+          },
+          {
+            "type": "finite_set_literal",
+            "named": true
+          },
+          {
+            "type": "function_evaluation",
+            "named": true
+          },
+          {
+            "type": "function_literal",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "if_then_else",
+            "named": true
+          },
+          {
+            "type": "label",
+            "named": true
+          },
+          {
+            "type": "let_in",
+            "named": true
+          },
+          {
+            "type": "number",
+            "named": true
+          },
+          {
+            "type": "parentheses",
+            "named": true
+          },
+          {
+            "type": "prefixed_op",
+            "named": true
+          },
+          {
+            "type": "prev_func_val",
+            "named": true
+          },
+          {
+            "type": "primitive_value_set",
+            "named": true
+          },
+          {
+            "type": "proof_step_id",
+            "named": true
+          },
+          {
+            "type": "record_literal",
+            "named": true
+          },
+          {
+            "type": "record_value",
+            "named": true
+          },
+          {
+            "type": "set_filter",
+            "named": true
+          },
+          {
+            "type": "set_map",
+            "named": true
+          },
+          {
+            "type": "set_of_functions",
+            "named": true
+          },
+          {
+            "type": "set_of_records",
+            "named": true
+          },
+          {
+            "type": "step_expr_no_stutter",
+            "named": true
+          },
+          {
+            "type": "step_expr_or_stutter",
+            "named": true
+          },
+          {
+            "type": "string",
+            "named": true
+          },
+          {
+            "type": "subexpression",
+            "named": true
+          },
+          {
+            "type": "tuple_literal",
+            "named": true
+          },
+          {
+            "type": "unbounded_quantification",
+            "named": true
+          }
+        ]
+      },
+      "generator": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "single_quantifier_bound",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "set_in",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "set_map",
+    "named": true,
+    "fields": {
+      "generator": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": ",",
+            "named": false
+          },
+          {
+            "type": "quantifier_bound",
+            "named": true
+          }
+        ]
+      },
+      "map": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "boolean",
+            "named": true
+          },
+          {
+            "type": "bound_infix_op",
+            "named": true
+          },
+          {
+            "type": "bound_nonfix_op",
+            "named": true
+          },
+          {
+            "type": "bound_op",
+            "named": true
+          },
+          {
+            "type": "bound_postfix_op",
+            "named": true
+          },
+          {
+            "type": "bound_prefix_op",
+            "named": true
+          },
+          {
+            "type": "bounded_quantification",
+            "named": true
+          },
+          {
+            "type": "case",
+            "named": true
+          },
+          {
+            "type": "choose",
+            "named": true
+          },
+          {
+            "type": "conj_list",
+            "named": true
+          },
+          {
+            "type": "disj_list",
+            "named": true
+          },
+          {
+            "type": "except",
+            "named": true
+          },
+          {
+            "type": "fairness",
+            "named": true
+          },
+          {
+            "type": "finite_set_literal",
+            "named": true
+          },
+          {
+            "type": "function_evaluation",
+            "named": true
+          },
+          {
+            "type": "function_literal",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "if_then_else",
+            "named": true
+          },
+          {
+            "type": "label",
+            "named": true
+          },
+          {
+            "type": "let_in",
+            "named": true
+          },
+          {
+            "type": "number",
+            "named": true
+          },
+          {
+            "type": "parentheses",
+            "named": true
+          },
+          {
+            "type": "prefixed_op",
+            "named": true
+          },
+          {
+            "type": "prev_func_val",
+            "named": true
+          },
+          {
+            "type": "primitive_value_set",
+            "named": true
+          },
+          {
+            "type": "proof_step_id",
+            "named": true
+          },
+          {
+            "type": "record_literal",
+            "named": true
+          },
+          {
+            "type": "record_value",
+            "named": true
+          },
+          {
+            "type": "set_filter",
+            "named": true
+          },
+          {
+            "type": "set_map",
+            "named": true
+          },
+          {
+            "type": "set_of_functions",
+            "named": true
+          },
+          {
+            "type": "set_of_records",
+            "named": true
+          },
+          {
+            "type": "step_expr_no_stutter",
+            "named": true
+          },
+          {
+            "type": "step_expr_or_stutter",
+            "named": true
+          },
+          {
+            "type": "string",
+            "named": true
+          },
+          {
+            "type": "subexpression",
+            "named": true
+          },
+          {
+            "type": "tuple_literal",
+            "named": true
+          },
+          {
+            "type": "unbounded_quantification",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "set_of_functions",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "bound_infix_op",
+          "named": true
+        },
+        {
+          "type": "bound_nonfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_op",
+          "named": true
+        },
+        {
+          "type": "bound_postfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_prefix_op",
+          "named": true
+        },
+        {
+          "type": "bounded_quantification",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "choose",
+          "named": true
+        },
+        {
+          "type": "conj_list",
+          "named": true
+        },
+        {
+          "type": "disj_list",
+          "named": true
+        },
+        {
+          "type": "except",
+          "named": true
+        },
+        {
+          "type": "fairness",
+          "named": true
+        },
+        {
+          "type": "finite_set_literal",
+          "named": true
+        },
+        {
+          "type": "function_evaluation",
+          "named": true
+        },
+        {
+          "type": "function_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "if_then_else",
+          "named": true
+        },
+        {
+          "type": "label",
+          "named": true
+        },
+        {
+          "type": "let_in",
+          "named": true
+        },
+        {
+          "type": "maps_to",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "parentheses",
+          "named": true
+        },
+        {
+          "type": "prefixed_op",
+          "named": true
+        },
+        {
+          "type": "prev_func_val",
+          "named": true
+        },
+        {
+          "type": "primitive_value_set",
+          "named": true
+        },
+        {
+          "type": "proof_step_id",
+          "named": true
+        },
+        {
+          "type": "record_literal",
+          "named": true
+        },
+        {
+          "type": "record_value",
+          "named": true
+        },
+        {
+          "type": "set_filter",
+          "named": true
+        },
+        {
+          "type": "set_map",
+          "named": true
+        },
+        {
+          "type": "set_of_functions",
+          "named": true
+        },
+        {
+          "type": "set_of_records",
+          "named": true
+        },
+        {
+          "type": "step_expr_no_stutter",
+          "named": true
+        },
+        {
+          "type": "step_expr_or_stutter",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "subexpression",
+          "named": true
+        },
+        {
+          "type": "tuple_literal",
+          "named": true
+        },
+        {
+          "type": "unbounded_quantification",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "set_of_records",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "bound_infix_op",
+          "named": true
+        },
+        {
+          "type": "bound_nonfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_op",
+          "named": true
+        },
+        {
+          "type": "bound_postfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_prefix_op",
+          "named": true
+        },
+        {
+          "type": "bounded_quantification",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "choose",
+          "named": true
+        },
+        {
+          "type": "conj_list",
+          "named": true
+        },
+        {
+          "type": "disj_list",
+          "named": true
+        },
+        {
+          "type": "except",
+          "named": true
+        },
+        {
+          "type": "fairness",
+          "named": true
+        },
+        {
+          "type": "finite_set_literal",
+          "named": true
+        },
+        {
+          "type": "function_evaluation",
+          "named": true
+        },
+        {
+          "type": "function_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "if_then_else",
+          "named": true
+        },
+        {
+          "type": "label",
+          "named": true
+        },
+        {
+          "type": "let_in",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "parentheses",
+          "named": true
+        },
+        {
+          "type": "prefixed_op",
+          "named": true
+        },
+        {
+          "type": "prev_func_val",
+          "named": true
+        },
+        {
+          "type": "primitive_value_set",
+          "named": true
+        },
+        {
+          "type": "proof_step_id",
+          "named": true
+        },
+        {
+          "type": "record_literal",
+          "named": true
+        },
+        {
+          "type": "record_value",
+          "named": true
+        },
+        {
+          "type": "set_filter",
+          "named": true
+        },
+        {
+          "type": "set_map",
+          "named": true
+        },
+        {
+          "type": "set_of_functions",
+          "named": true
+        },
+        {
+          "type": "set_of_records",
+          "named": true
+        },
+        {
+          "type": "step_expr_no_stutter",
+          "named": true
+        },
+        {
+          "type": "step_expr_or_stutter",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "subexpression",
+          "named": true
+        },
+        {
+          "type": "tuple_literal",
+          "named": true
+        },
+        {
+          "type": "unbounded_quantification",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "sim",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "simeq",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "single_quantifier_bound",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "bound_infix_op",
+          "named": true
+        },
+        {
+          "type": "bound_nonfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_op",
+          "named": true
+        },
+        {
+          "type": "bound_postfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_prefix_op",
+          "named": true
+        },
+        {
+          "type": "bounded_quantification",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "choose",
+          "named": true
+        },
+        {
+          "type": "conj_list",
+          "named": true
+        },
+        {
+          "type": "disj_list",
+          "named": true
+        },
+        {
+          "type": "except",
+          "named": true
+        },
+        {
+          "type": "fairness",
+          "named": true
+        },
+        {
+          "type": "finite_set_literal",
+          "named": true
+        },
+        {
+          "type": "function_evaluation",
+          "named": true
+        },
+        {
+          "type": "function_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "if_then_else",
+          "named": true
+        },
+        {
+          "type": "label",
+          "named": true
+        },
+        {
+          "type": "let_in",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "parentheses",
+          "named": true
+        },
+        {
+          "type": "prefixed_op",
+          "named": true
+        },
+        {
+          "type": "prev_func_val",
+          "named": true
+        },
+        {
+          "type": "primitive_value_set",
+          "named": true
+        },
+        {
+          "type": "proof_step_id",
+          "named": true
+        },
+        {
+          "type": "record_literal",
+          "named": true
+        },
+        {
+          "type": "record_value",
+          "named": true
+        },
+        {
+          "type": "set_filter",
+          "named": true
+        },
+        {
+          "type": "set_in",
+          "named": true
+        },
+        {
+          "type": "set_map",
+          "named": true
+        },
+        {
+          "type": "set_of_functions",
+          "named": true
+        },
+        {
+          "type": "set_of_records",
+          "named": true
+        },
+        {
+          "type": "step_expr_no_stutter",
+          "named": true
+        },
+        {
+          "type": "step_expr_or_stutter",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "subexpression",
+          "named": true
+        },
+        {
+          "type": "tuple_literal",
+          "named": true
+        },
+        {
+          "type": "tuple_of_identifiers",
+          "named": true
+        },
+        {
+          "type": "unbounded_quantification",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "source_file",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "module",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "sqcap",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "sqcup",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "sqsubset",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "sqsubseteq",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "sqsupset",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "sqsupseteq",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "standalone_prefix_op_symbol",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "always",
+          "named": true
+        },
+        {
+          "type": "domain",
+          "named": true
+        },
+        {
+          "type": "enabled",
+          "named": true
+        },
+        {
+          "type": "eventually",
+          "named": true
+        },
+        {
+          "type": "lnot",
+          "named": true
+        },
+        {
+          "type": "negative",
+          "named": true
+        },
+        {
+          "type": "powerset",
+          "named": true
+        },
+        {
+          "type": "unchanged",
+          "named": true
+        },
+        {
+          "type": "union",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "star",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "step_expr_no_stutter",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "bound_infix_op",
+          "named": true
+        },
+        {
+          "type": "bound_nonfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_op",
+          "named": true
+        },
+        {
+          "type": "bound_postfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_prefix_op",
+          "named": true
+        },
+        {
+          "type": "bounded_quantification",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "choose",
+          "named": true
+        },
+        {
+          "type": "conj_list",
+          "named": true
+        },
+        {
+          "type": "disj_list",
+          "named": true
+        },
+        {
+          "type": "except",
+          "named": true
+        },
+        {
+          "type": "fairness",
+          "named": true
+        },
+        {
+          "type": "finite_set_literal",
+          "named": true
+        },
+        {
+          "type": "function_evaluation",
+          "named": true
+        },
+        {
+          "type": "function_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "if_then_else",
+          "named": true
+        },
+        {
+          "type": "label",
+          "named": true
+        },
+        {
+          "type": "langle_bracket",
+          "named": true
+        },
+        {
+          "type": "let_in",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "parentheses",
+          "named": true
+        },
+        {
+          "type": "prefixed_op",
+          "named": true
+        },
+        {
+          "type": "prev_func_val",
+          "named": true
+        },
+        {
+          "type": "primitive_value_set",
+          "named": true
+        },
+        {
+          "type": "proof_step_id",
+          "named": true
+        },
+        {
+          "type": "rangle_bracket",
+          "named": true
+        },
+        {
+          "type": "record_literal",
+          "named": true
+        },
+        {
+          "type": "record_value",
+          "named": true
+        },
+        {
+          "type": "set_filter",
+          "named": true
+        },
+        {
+          "type": "set_map",
+          "named": true
+        },
+        {
+          "type": "set_of_functions",
+          "named": true
+        },
+        {
+          "type": "set_of_records",
+          "named": true
+        },
+        {
+          "type": "step_expr_no_stutter",
+          "named": true
+        },
+        {
+          "type": "step_expr_or_stutter",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "subexpression",
+          "named": true
+        },
+        {
+          "type": "tuple_literal",
+          "named": true
+        },
+        {
+          "type": "unbounded_quantification",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "step_expr_or_stutter",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "bound_infix_op",
+          "named": true
+        },
+        {
+          "type": "bound_nonfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_op",
+          "named": true
+        },
+        {
+          "type": "bound_postfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_prefix_op",
+          "named": true
+        },
+        {
+          "type": "bounded_quantification",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "choose",
+          "named": true
+        },
+        {
+          "type": "conj_list",
+          "named": true
+        },
+        {
+          "type": "disj_list",
+          "named": true
+        },
+        {
+          "type": "except",
+          "named": true
+        },
+        {
+          "type": "fairness",
+          "named": true
+        },
+        {
+          "type": "finite_set_literal",
+          "named": true
+        },
+        {
+          "type": "function_evaluation",
+          "named": true
+        },
+        {
+          "type": "function_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "if_then_else",
+          "named": true
+        },
+        {
+          "type": "label",
+          "named": true
+        },
+        {
+          "type": "let_in",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "parentheses",
+          "named": true
+        },
+        {
+          "type": "prefixed_op",
+          "named": true
+        },
+        {
+          "type": "prev_func_val",
+          "named": true
+        },
+        {
+          "type": "primitive_value_set",
+          "named": true
+        },
+        {
+          "type": "proof_step_id",
+          "named": true
+        },
+        {
+          "type": "record_literal",
+          "named": true
+        },
+        {
+          "type": "record_value",
+          "named": true
+        },
+        {
+          "type": "set_filter",
+          "named": true
+        },
+        {
+          "type": "set_map",
+          "named": true
+        },
+        {
+          "type": "set_of_functions",
+          "named": true
+        },
+        {
+          "type": "set_of_records",
+          "named": true
+        },
+        {
+          "type": "step_expr_no_stutter",
+          "named": true
+        },
+        {
+          "type": "step_expr_or_stutter",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "subexpression",
+          "named": true
+        },
+        {
+          "type": "tuple_literal",
+          "named": true
+        },
+        {
+          "type": "unbounded_quantification",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "subexpr_component",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "bound_nonfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_op",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "infix_op_symbol",
+          "named": true
+        },
+        {
+          "type": "postfix_op_symbol",
+          "named": true
+        },
+        {
+          "type": "standalone_prefix_op_symbol",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "subexpr_prefix",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "proof_step_id",
+          "named": true
+        },
+        {
+          "type": "subexpr_component",
+          "named": true
+        },
+        {
+          "type": "subexpr_tree_nav",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "subexpr_tree_nav",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "address",
+          "named": true
+        },
+        {
+          "type": "colon",
+          "named": true
+        },
+        {
+          "type": "langle_bracket",
+          "named": true
+        },
+        {
+          "type": "nat_number",
+          "named": true
+        },
+        {
+          "type": "operator_args",
+          "named": true
+        },
+        {
+          "type": "rangle_bracket",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "subexpression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "subexpr_prefix",
+          "named": true
+        },
+        {
+          "type": "subexpr_tree_nav",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "subset",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "subseteq",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "substitution",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "gets",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "infix_op_symbol",
+          "named": true
+        },
+        {
+          "type": "op_or_expr",
+          "named": true
+        },
+        {
+          "type": "postfix_op_symbol",
+          "named": true
+        },
+        {
+          "type": "standalone_prefix_op_symbol",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "succ",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "succeq",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "sup_plus",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "supset",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "supseteq",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "temporal_exists",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "temporal_forall",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "terminal_proof",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "use_body",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "theorem",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "assume_prove",
+          "named": true
+        },
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "bound_infix_op",
+          "named": true
+        },
+        {
+          "type": "bound_nonfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_op",
+          "named": true
+        },
+        {
+          "type": "bound_postfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_prefix_op",
+          "named": true
+        },
+        {
+          "type": "bounded_quantification",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "choose",
+          "named": true
+        },
+        {
+          "type": "conj_list",
+          "named": true
+        },
+        {
+          "type": "def_eq",
+          "named": true
+        },
+        {
+          "type": "disj_list",
+          "named": true
+        },
+        {
+          "type": "except",
+          "named": true
+        },
+        {
+          "type": "fairness",
+          "named": true
+        },
+        {
+          "type": "finite_set_literal",
+          "named": true
+        },
+        {
+          "type": "function_evaluation",
+          "named": true
+        },
+        {
+          "type": "function_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "if_then_else",
+          "named": true
+        },
+        {
+          "type": "label",
+          "named": true
+        },
+        {
+          "type": "let_in",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "parentheses",
+          "named": true
+        },
+        {
+          "type": "prefixed_op",
+          "named": true
+        },
+        {
+          "type": "prev_func_val",
+          "named": true
+        },
+        {
+          "type": "primitive_value_set",
+          "named": true
+        },
+        {
+          "type": "proof",
+          "named": true
+        },
+        {
+          "type": "proof_step_id",
+          "named": true
+        },
+        {
+          "type": "record_literal",
+          "named": true
+        },
+        {
+          "type": "record_value",
+          "named": true
+        },
+        {
+          "type": "set_filter",
+          "named": true
+        },
+        {
+          "type": "set_map",
+          "named": true
+        },
+        {
+          "type": "set_of_functions",
+          "named": true
+        },
+        {
+          "type": "set_of_records",
+          "named": true
+        },
+        {
+          "type": "step_expr_no_stutter",
+          "named": true
+        },
+        {
+          "type": "step_expr_or_stutter",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "subexpression",
+          "named": true
+        },
+        {
+          "type": "tuple_literal",
+          "named": true
+        },
+        {
+          "type": "unbounded_quantification",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "times",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "tuple_literal",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "bound_infix_op",
+          "named": true
+        },
+        {
+          "type": "bound_nonfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_op",
+          "named": true
+        },
+        {
+          "type": "bound_postfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_prefix_op",
+          "named": true
+        },
+        {
+          "type": "bounded_quantification",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "choose",
+          "named": true
+        },
+        {
+          "type": "conj_list",
+          "named": true
+        },
+        {
+          "type": "disj_list",
+          "named": true
+        },
+        {
+          "type": "except",
+          "named": true
+        },
+        {
+          "type": "fairness",
+          "named": true
+        },
+        {
+          "type": "finite_set_literal",
+          "named": true
+        },
+        {
+          "type": "function_evaluation",
+          "named": true
+        },
+        {
+          "type": "function_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "if_then_else",
+          "named": true
+        },
+        {
+          "type": "label",
+          "named": true
+        },
+        {
+          "type": "langle_bracket",
+          "named": true
+        },
+        {
+          "type": "let_in",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "parentheses",
+          "named": true
+        },
+        {
+          "type": "prefixed_op",
+          "named": true
+        },
+        {
+          "type": "prev_func_val",
+          "named": true
+        },
+        {
+          "type": "primitive_value_set",
+          "named": true
+        },
+        {
+          "type": "proof_step_id",
+          "named": true
+        },
+        {
+          "type": "rangle_bracket",
+          "named": true
+        },
+        {
+          "type": "record_literal",
+          "named": true
+        },
+        {
+          "type": "record_value",
+          "named": true
+        },
+        {
+          "type": "set_filter",
+          "named": true
+        },
+        {
+          "type": "set_map",
+          "named": true
+        },
+        {
+          "type": "set_of_functions",
+          "named": true
+        },
+        {
+          "type": "set_of_records",
+          "named": true
+        },
+        {
+          "type": "step_expr_no_stutter",
+          "named": true
+        },
+        {
+          "type": "step_expr_or_stutter",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "subexpression",
+          "named": true
+        },
+        {
+          "type": "tuple_literal",
+          "named": true
+        },
+        {
+          "type": "unbounded_quantification",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "tuple_of_identifiers",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "langle_bracket",
+          "named": true
+        },
+        {
+          "type": "rangle_bracket",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "unbounded_quantification",
+    "named": true,
+    "fields": {
+      "expression": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "boolean",
+            "named": true
+          },
+          {
+            "type": "bound_infix_op",
+            "named": true
+          },
+          {
+            "type": "bound_nonfix_op",
+            "named": true
+          },
+          {
+            "type": "bound_op",
+            "named": true
+          },
+          {
+            "type": "bound_postfix_op",
+            "named": true
+          },
+          {
+            "type": "bound_prefix_op",
+            "named": true
+          },
+          {
+            "type": "bounded_quantification",
+            "named": true
+          },
+          {
+            "type": "case",
+            "named": true
+          },
+          {
+            "type": "choose",
+            "named": true
+          },
+          {
+            "type": "conj_list",
+            "named": true
+          },
+          {
+            "type": "disj_list",
+            "named": true
+          },
+          {
+            "type": "except",
+            "named": true
+          },
+          {
+            "type": "fairness",
+            "named": true
+          },
+          {
+            "type": "finite_set_literal",
+            "named": true
+          },
+          {
+            "type": "function_evaluation",
+            "named": true
+          },
+          {
+            "type": "function_literal",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "if_then_else",
+            "named": true
+          },
+          {
+            "type": "label",
+            "named": true
+          },
+          {
+            "type": "let_in",
+            "named": true
+          },
+          {
+            "type": "number",
+            "named": true
+          },
+          {
+            "type": "parentheses",
+            "named": true
+          },
+          {
+            "type": "prefixed_op",
+            "named": true
+          },
+          {
+            "type": "prev_func_val",
+            "named": true
+          },
+          {
+            "type": "primitive_value_set",
+            "named": true
+          },
+          {
+            "type": "proof_step_id",
+            "named": true
+          },
+          {
+            "type": "record_literal",
+            "named": true
+          },
+          {
+            "type": "record_value",
+            "named": true
+          },
+          {
+            "type": "set_filter",
+            "named": true
+          },
+          {
+            "type": "set_map",
+            "named": true
+          },
+          {
+            "type": "set_of_functions",
+            "named": true
+          },
+          {
+            "type": "set_of_records",
+            "named": true
+          },
+          {
+            "type": "step_expr_no_stutter",
+            "named": true
+          },
+          {
+            "type": "step_expr_or_stutter",
+            "named": true
+          },
+          {
+            "type": "string",
+            "named": true
+          },
+          {
+            "type": "subexpression",
+            "named": true
+          },
+          {
+            "type": "tuple_literal",
+            "named": true
+          },
+          {
+            "type": "unbounded_quantification",
+            "named": true
+          }
+        ]
+      },
+      "identifier": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": ",",
+            "named": false
+          },
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      },
+      "quantifier": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "exists",
+            "named": true
+          },
+          {
+            "type": "forall",
+            "named": true
+          },
+          {
+            "type": "temporal_exists",
+            "named": true
+          },
+          {
+            "type": "temporal_forall",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "unchanged",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "union",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "unit",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "assumption",
+          "named": true
+        },
+        {
+          "type": "constant_declaration",
+          "named": true
+        },
+        {
+          "type": "function_definition",
+          "named": true
+        },
+        {
+          "type": "instance",
+          "named": true
+        },
+        {
+          "type": "module",
+          "named": true
+        },
+        {
+          "type": "module_definition",
+          "named": true
+        },
+        {
+          "type": "operator_definition",
+          "named": true
+        },
+        {
+          "type": "recursive_operator_declaration",
+          "named": true
+        },
+        {
+          "type": "theorem",
+          "named": true
+        },
+        {
+          "type": "variable_declaration",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "uplus",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "use_body",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "use_body_def",
+          "named": true
+        },
+        {
+          "type": "use_body_expr",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "use_body_def",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "op_or_expr",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "use_body_expr",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "bound_infix_op",
+          "named": true
+        },
+        {
+          "type": "bound_nonfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_op",
+          "named": true
+        },
+        {
+          "type": "bound_postfix_op",
+          "named": true
+        },
+        {
+          "type": "bound_prefix_op",
+          "named": true
+        },
+        {
+          "type": "bounded_quantification",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "choose",
+          "named": true
+        },
+        {
+          "type": "conj_list",
+          "named": true
+        },
+        {
+          "type": "disj_list",
+          "named": true
+        },
+        {
+          "type": "except",
+          "named": true
+        },
+        {
+          "type": "fairness",
+          "named": true
+        },
+        {
+          "type": "finite_set_literal",
+          "named": true
+        },
+        {
+          "type": "function_evaluation",
+          "named": true
+        },
+        {
+          "type": "function_literal",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "if_then_else",
+          "named": true
+        },
+        {
+          "type": "label",
+          "named": true
+        },
+        {
+          "type": "let_in",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "parentheses",
+          "named": true
+        },
+        {
+          "type": "prefixed_op",
+          "named": true
+        },
+        {
+          "type": "prev_func_val",
+          "named": true
+        },
+        {
+          "type": "primitive_value_set",
+          "named": true
+        },
+        {
+          "type": "proof_step_id",
+          "named": true
+        },
+        {
+          "type": "record_literal",
+          "named": true
+        },
+        {
+          "type": "record_value",
+          "named": true
+        },
+        {
+          "type": "set_filter",
+          "named": true
+        },
+        {
+          "type": "set_map",
+          "named": true
+        },
+        {
+          "type": "set_of_functions",
+          "named": true
+        },
+        {
+          "type": "set_of_records",
+          "named": true
+        },
+        {
+          "type": "step_expr_no_stutter",
+          "named": true
+        },
+        {
+          "type": "step_expr_or_stutter",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "subexpression",
+          "named": true
+        },
+        {
+          "type": "tuple_literal",
+          "named": true
+        },
+        {
+          "type": "unbounded_quantification",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "use_or_hide",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "use_body",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "variable_declaration",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "vertvert",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "wr",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "!",
+    "named": false
+  },
+  {
+    "type": "!!",
+    "named": false
+  },
+  {
+    "type": "#",
+    "named": false
+  },
+  {
+    "type": "(",
+    "named": false
+  },
+  {
+    "type": "(+)",
+    "named": false
+  },
+  {
+    "type": "(-)",
+    "named": false
+  },
+  {
+    "type": "(.)",
+    "named": false
+  },
+  {
+    "type": "(/)",
+    "named": false
+  },
+  {
+    "type": "(\\X)",
+    "named": false
+  },
+  {
+    "type": ")",
+    "named": false
+  },
+  {
+    "type": ",",
+    "named": false
+  },
+  {
+    "type": "-",
+    "named": false
+  },
+  {
+    "type": "-+->",
+    "named": false
+  },
+  {
+    "type": "----",
+    "named": false
+  },
+  {
+    "type": "->",
+    "named": false
+  },
+  {
+    "type": "-|",
+    "named": false
+  },
+  {
+    "type": ".",
+    "named": false
+  },
+  {
+    "type": "..",
+    "named": false
+  },
+  {
+    "type": "...",
+    "named": false
+  },
+  {
+    "type": "/=",
+    "named": false
+  },
+  {
+    "type": "/\\",
+    "named": false
+  },
+  {
+    "type": ":",
+    "named": false
+  },
+  {
+    "type": "::",
+    "named": false
+  },
+  {
+    "type": "::=",
+    "named": false
+  },
+  {
+    "type": ":=",
+    "named": false
+  },
+  {
+    "type": "<-",
+    "named": false
+  },
+  {
+    "type": "<<",
+    "named": false
+  },
+  {
+    "type": "<=",
+    "named": false
+  },
+  {
+    "type": "<=>",
+    "named": false
+  },
+  {
+    "type": "<>",
+    "named": false
+  },
+  {
+    "type": "=",
+    "named": false
+  },
+  {
+    "type": "==",
+    "named": false
+  },
+  {
+    "type": "====",
+    "named": false
+  },
+  {
+    "type": "=>",
+    "named": false
+  },
+  {
+    "type": "=|",
+    "named": false
+  },
+  {
+    "type": ">=",
+    "named": false
+  },
+  {
+    "type": ">>",
+    "named": false
+  },
+  {
+    "type": "??",
+    "named": false
+  },
+  {
+    "type": "@",
+    "named": false
+  },
+  {
+    "type": "ACTION",
+    "named": false
+  },
+  {
+    "type": "ASSUME",
+    "named": false
+  },
+  {
+    "type": "ASSUMPTION",
+    "named": false
+  },
+  {
+    "type": "AXIOM",
+    "named": false
+  },
+  {
+    "type": "BOOLEAN",
+    "named": false
+  },
+  {
+    "type": "BY",
+    "named": false
+  },
+  {
+    "type": "CASE",
+    "named": false
+  },
+  {
+    "type": "CHOOSE",
+    "named": false
+  },
+  {
+    "type": "CONSTANT",
+    "named": false
+  },
+  {
+    "type": "CONSTANTS",
+    "named": false
+  },
+  {
+    "type": "COROLLARY",
+    "named": false
+  },
+  {
+    "type": "DEF",
+    "named": false
+  },
+  {
+    "type": "DEFINE",
+    "named": false
+  },
+  {
+    "type": "DEFS",
+    "named": false
+  },
+  {
+    "type": "DOMAIN",
+    "named": false
+  },
+  {
+    "type": "ELSE",
+    "named": false
+  },
+  {
+    "type": "ENABLED",
+    "named": false
+  },
+  {
+    "type": "EXCEPT",
+    "named": false
+  },
+  {
+    "type": "EXTENDS",
+    "named": false
+  },
+  {
+    "type": "FALSE",
+    "named": false
+  },
+  {
+    "type": "HAVE",
+    "named": false
+  },
+  {
+    "type": "HIDE",
+    "named": false
+  },
+  {
+    "type": "IF",
+    "named": false
+  },
+  {
+    "type": "IN",
+    "named": false
+  },
+  {
+    "type": "INSTANCE",
+    "named": false
+  },
+  {
+    "type": "Int",
+    "named": false
+  },
+  {
+    "type": "LAMBDA",
+    "named": false
+  },
+  {
+    "type": "LEMMA",
+    "named": false
+  },
+  {
+    "type": "LET",
+    "named": false
+  },
+  {
+    "type": "LOCAL",
+    "named": false
+  },
+  {
+    "type": "MODULE",
+    "named": false
+  },
+  {
+    "type": "NEW",
+    "named": false
+  },
+  {
+    "type": "Nat",
+    "named": false
+  },
+  {
+    "type": "OBVIOUS",
+    "named": false
+  },
+  {
+    "type": "OMITTED",
+    "named": false
+  },
+  {
+    "type": "ONLY",
+    "named": false
+  },
+  {
+    "type": "OTHER",
+    "named": false
+  },
+  {
+    "type": "PICK",
+    "named": false
+  },
+  {
+    "type": "PROOF",
+    "named": false
+  },
+  {
+    "type": "PROPOSITION",
+    "named": false
+  },
+  {
+    "type": "PROVE",
+    "named": false
+  },
+  {
+    "type": "QED",
+    "named": false
+  },
+  {
+    "type": "RECURSIVE",
+    "named": false
+  },
+  {
+    "type": "Real",
+    "named": false
+  },
+  {
+    "type": "SF_",
+    "named": false
+  },
+  {
+    "type": "STATE",
+    "named": false
+  },
+  {
+    "type": "STRING",
+    "named": false
+  },
+  {
+    "type": "SUBSET",
+    "named": false
+  },
+  {
+    "type": "SUFFICES",
+    "named": false
+  },
+  {
+    "type": "TAKE",
+    "named": false
+  },
+  {
+    "type": "TEMPORAL",
+    "named": false
+  },
+  {
+    "type": "THEN",
+    "named": false
+  },
+  {
+    "type": "THEOREM",
+    "named": false
+  },
+  {
+    "type": "TRUE",
+    "named": false
+  },
+  {
+    "type": "UNCHANGED",
+    "named": false
+  },
+  {
+    "type": "UNION",
+    "named": false
+  },
+  {
+    "type": "USE",
+    "named": false
+  },
+  {
+    "type": "VARIABLE",
+    "named": false
+  },
+  {
+    "type": "VARIABLES",
+    "named": false
+  },
+  {
+    "type": "WF_",
+    "named": false
+  },
+  {
+    "type": "WITH",
+    "named": false
+  },
+  {
+    "type": "WITNESS",
+    "named": false
+  },
+  {
+    "type": "[",
+    "named": false
+  },
+  {
+    "type": "[]",
+    "named": false
+  },
+  {
+    "type": "\\/",
+    "named": false
+  },
+  {
+    "type": "\\A",
+    "named": false
+  },
+  {
+    "type": "\\AA",
+    "named": false
+  },
+  {
+    "type": "\\E",
+    "named": false
+  },
+  {
+    "type": "\\EE",
+    "named": false
+  },
+  {
+    "type": "\\X",
+    "named": false
+  },
+  {
+    "type": "\\approx",
+    "named": false
+  },
+  {
+    "type": "\\asymp",
+    "named": false
+  },
+  {
+    "type": "\\bigcirc",
+    "named": false
+  },
+  {
+    "type": "\\bullet",
+    "named": false
+  },
+  {
+    "type": "\\cap",
+    "named": false
+  },
+  {
+    "type": "\\cdot",
+    "named": false
+  },
+  {
+    "type": "\\circ",
+    "named": false
+  },
+  {
+    "type": "\\cong",
+    "named": false
+  },
+  {
+    "type": "\\cup",
+    "named": false
+  },
+  {
+    "type": "\\div",
+    "named": false
+  },
+  {
+    "type": "\\doteq",
+    "named": false
+  },
+  {
+    "type": "\\equiv",
+    "named": false
+  },
+  {
+    "type": "\\exists",
+    "named": false
+  },
+  {
+    "type": "\\forall",
+    "named": false
+  },
+  {
+    "type": "\\geq",
+    "named": false
+  },
+  {
+    "type": "\\gg",
+    "named": false
+  },
+  {
+    "type": "\\in",
+    "named": false
+  },
+  {
+    "type": "\\land",
+    "named": false
+  },
+  {
+    "type": "\\leq",
+    "named": false
+  },
+  {
+    "type": "\\ll",
+    "named": false
+  },
+  {
+    "type": "\\lnot",
+    "named": false
+  },
+  {
+    "type": "\\lor",
+    "named": false
+  },
+  {
+    "type": "\\neg",
+    "named": false
+  },
+  {
+    "type": "\\notin",
+    "named": false
+  },
+  {
+    "type": "\\odot",
+    "named": false
+  },
+  {
+    "type": "\\ominus",
+    "named": false
+  },
+  {
+    "type": "\\oplus",
+    "named": false
+  },
+  {
+    "type": "\\oslash",
+    "named": false
+  },
+  {
+    "type": "\\otimes",
+    "named": false
+  },
+  {
+    "type": "\\prec",
+    "named": false
+  },
+  {
+    "type": "\\preceq",
+    "named": false
+  },
+  {
+    "type": "\\propto",
+    "named": false
+  },
+  {
+    "type": "\\sim",
+    "named": false
+  },
+  {
+    "type": "\\simeq",
+    "named": false
+  },
+  {
+    "type": "\\sqcap",
+    "named": false
+  },
+  {
+    "type": "\\sqcup",
+    "named": false
+  },
+  {
+    "type": "\\sqsubset",
+    "named": false
+  },
+  {
+    "type": "\\sqsubseteq",
+    "named": false
+  },
+  {
+    "type": "\\sqsupset",
+    "named": false
+  },
+  {
+    "type": "\\sqsupseteq",
+    "named": false
+  },
+  {
+    "type": "\\star",
+    "named": false
+  },
+  {
+    "type": "\\subset",
+    "named": false
+  },
+  {
+    "type": "\\subseteq",
+    "named": false
+  },
+  {
+    "type": "\\succ",
+    "named": false
+  },
+  {
+    "type": "\\succeq",
+    "named": false
+  },
+  {
+    "type": "\\supset",
+    "named": false
+  },
+  {
+    "type": "\\supseteq",
+    "named": false
+  },
+  {
+    "type": "\\times",
+    "named": false
+  },
+  {
+    "type": "\\uplus",
+    "named": false
+  },
+  {
+    "type": "\\wr",
+    "named": false
+  },
+  {
+    "type": "]",
+    "named": false
+  },
+  {
+    "type": "]_",
+    "named": false
+  },
+  {
+    "type": "^+",
+    "named": false
+  },
+  {
+    "type": "_",
+    "named": false
+  },
+  {
+    "type": "amp",
+    "named": true
+  },
+  {
+    "type": "ampamp",
+    "named": true
+  },
+  {
+    "type": "asterisk",
+    "named": true
+  },
+  {
+    "type": "begin_proof_step_token",
+    "named": true
+  },
+  {
+    "type": "binary_number",
+    "named": true
+  },
+  {
+    "type": "compose",
+    "named": true
+  },
+  {
+    "type": "dol",
+    "named": true
+  },
+  {
+    "type": "doldol",
+    "named": true
+  },
+  {
+    "type": "gt",
+    "named": true
+  },
+  {
+    "type": "hashhash",
+    "named": true
+  },
+  {
+    "type": "hex_number",
+    "named": true
+  },
+  {
+    "type": "identifier",
+    "named": true
+  },
+  {
+    "type": "lt",
+    "named": true
+  },
+  {
+    "type": "map_from",
+    "named": true
+  },
+  {
+    "type": "map_to",
+    "named": true
+  },
+  {
+    "type": "minusminus",
+    "named": true
+  },
+  {
+    "type": "mod",
+    "named": true
+  },
+  {
+    "type": "modmod",
+    "named": true
+  },
+  {
+    "type": "mul",
+    "named": true
+  },
+  {
+    "type": "mulmul",
+    "named": true
+  },
+  {
+    "type": "multi_line_comment",
+    "named": true
+  },
+  {
+    "type": "nat_number",
+    "named": true
+  },
+  {
+    "type": "octal_number",
+    "named": true
+  },
+  {
+    "type": "placeholder",
+    "named": true
+  },
+  {
+    "type": "plus",
+    "named": true
+  },
+  {
+    "type": "plusplus",
+    "named": true
+  },
+  {
+    "type": "pow",
+    "named": true
+  },
+  {
+    "type": "powpow",
+    "named": true
+  },
+  {
+    "type": "prime",
+    "named": true
+  },
+  {
+    "type": "proof_step_id",
+    "named": true
+  },
+  {
+    "type": "real_number",
+    "named": true
+  },
+  {
+    "type": "setminus",
+    "named": true
+  },
+  {
+    "type": "single_line_comment",
+    "named": true
+  },
+  {
+    "type": "slash",
+    "named": true
+  },
+  {
+    "type": "slashslash",
+    "named": true
+  },
+  {
+    "type": "string",
+    "named": true
+  },
+  {
+    "type": "sup_hash",
+    "named": true
+  },
+  {
+    "type": "vert",
+    "named": true
+  },
+  {
+    "type": "{",
+    "named": false
+  },
+  {
+    "type": "|-",
+    "named": false
+  },
+  {
+    "type": "|->",
+    "named": false
+  },
+  {
+    "type": "|=",
+    "named": false
+  },
+  {
+    "type": "||",
+    "named": false
+  },
+  {
+    "type": "}",
+    "named": false
+  },
+  {
+    "type": "~",
+    "named": false
+  },
+  {
+    "type": "~>",
+    "named": false
+  },
+  {
+    "type": "¬",
+    "named": false
+  },
+  {
+    "type": "×",
+    "named": false
+  },
+  {
+    "type": "÷",
+    "named": false
+  },
+  {
+    "type": "‖",
+    "named": false
+  },
+  {
+    "type": "‥",
+    "named": false
+  },
+  {
+    "type": "…",
+    "named": false
+  },
+  {
+    "type": "‼",
+    "named": false
+  },
+  {
+    "type": "⁇",
+    "named": false
+  },
+  {
+    "type": "⁺",
+    "named": false
+  },
+  {
+    "type": "⇝",
+    "named": false
+  },
+  {
+    "type": "⇸",
+    "named": false
+  },
+  {
+    "type": "∀",
+    "named": false
+  },
+  {
+    "type": "∃",
+    "named": false
+  },
+  {
+    "type": "∈",
+    "named": false
+  },
+  {
+    "type": "∉",
+    "named": false
+  },
+  {
+    "type": "∘",
+    "named": false
+  },
+  {
+    "type": "∝",
+    "named": false
+  },
+  {
+    "type": "∧",
+    "named": false
+  },
+  {
+    "type": "∨",
+    "named": false
+  },
+  {
+    "type": "∩",
+    "named": false
+  },
+  {
+    "type": "∪",
+    "named": false
+  },
+  {
+    "type": "∷",
+    "named": false
+  },
+  {
+    "type": "∼",
+    "named": false
+  },
+  {
+    "type": "≀",
+    "named": false
+  },
+  {
+    "type": "≃",
+    "named": false
+  },
+  {
+    "type": "≅",
+    "named": false
+  },
+  {
+    "type": "≈",
+    "named": false
+  },
+  {
+    "type": "≍",
+    "named": false
+  },
+  {
+    "type": "≐",
+    "named": false
+  },
+  {
+    "type": "≔",
+    "named": false
+  },
+  {
+    "type": "≜",
+    "named": false
+  },
+  {
+    "type": "≠",
+    "named": false
+  },
+  {
+    "type": "≡",
+    "named": false
+  },
+  {
+    "type": "≤",
+    "named": false
+  },
+  {
+    "type": "≥",
+    "named": false
+  },
+  {
+    "type": "≪",
+    "named": false
+  },
+  {
+    "type": "≫",
+    "named": false
+  },
+  {
+    "type": "≺",
+    "named": false
+  },
+  {
+    "type": "≻",
+    "named": false
+  },
+  {
+    "type": "⊂",
+    "named": false
+  },
+  {
+    "type": "⊃",
+    "named": false
+  },
+  {
+    "type": "⊆",
+    "named": false
+  },
+  {
+    "type": "⊇",
+    "named": false
+  },
+  {
+    "type": "⊎",
+    "named": false
+  },
+  {
+    "type": "⊏",
+    "named": false
+  },
+  {
+    "type": "⊐",
+    "named": false
+  },
+  {
+    "type": "⊑",
+    "named": false
+  },
+  {
+    "type": "⊒",
+    "named": false
+  },
+  {
+    "type": "⊓",
+    "named": false
+  },
+  {
+    "type": "⊔",
+    "named": false
+  },
+  {
+    "type": "⊕",
+    "named": false
+  },
+  {
+    "type": "⊖",
+    "named": false
+  },
+  {
+    "type": "⊗",
+    "named": false
+  },
+  {
+    "type": "⊘",
+    "named": false
+  },
+  {
+    "type": "⊙",
+    "named": false
+  },
+  {
+    "type": "⊢",
+    "named": false
+  },
+  {
+    "type": "⊣",
+    "named": false
+  },
+  {
+    "type": "⊨",
+    "named": false
+  },
+  {
+    "type": "⋄",
+    "named": false
+  },
+  {
+    "type": "⋅",
+    "named": false
+  },
+  {
+    "type": "⋆",
+    "named": false
+  },
+  {
+    "type": "□",
+    "named": false
+  },
+  {
+    "type": "●",
+    "named": false
+  },
+  {
+    "type": "◯",
+    "named": false
+  },
+  {
+    "type": "⟵",
+    "named": false
+  },
+  {
+    "type": "⟶",
+    "named": false
+  },
+  {
+    "type": "⟹",
+    "named": false
+  },
+  {
+    "type": "⟺",
+    "named": false
+  },
+  {
+    "type": "⟼",
+    "named": false
+  },
+  {
+    "type": "⩴",
+    "named": false
+  },
+  {
+    "type": "⪯",
+    "named": false
+  },
+  {
+    "type": "⪰",
+    "named": false
+  },
+  {
+    "type": "⫤",
+    "named": false
+  },
+  {
+    "type": "〈",
+    "named": false
+  },
+  {
+    "type": "〉",
+    "named": false
+  }
+]

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -1,6 +1,7 @@
 #include <tree_sitter/parser.h>
 #include <cassert>
 #include <vector>
+#include <string>
 
 namespace {
 
@@ -166,14 +167,14 @@ namespace {
     }
 
     switch (next_codepoint(lexer)) {
-      case '∧': return LAND;
+      case L'∧': return LAND;
       case '/': return is_next_token(lexer, LAND_TOKEN) ? LAND : OTHER;
-      case '∨': return LOR;
+      case L'∨': return LOR;
       case '\\': return is_next_token(lexer, LOR_TOKEN) ? LOR : OTHER;
       case ')': return RIGHT_DELIMITER;
       case ']': return RIGHT_DELIMITER;
       case '}': return RIGHT_DELIMITER;
-      case '〉': return RIGHT_DELIMITER;
+      case L'〉': return RIGHT_DELIMITER;
       case 'T': // IF/THEN
         return is_next_token(lexer, THEN_TOKEN)
           ? RIGHT_DELIMITER : OTHER;

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -1,7 +1,7 @@
 #include <tree_sitter/parser.h>
 #include <cassert>
 #include <vector>
-#include <string>
+#include <cstring>
 
 namespace {
 
@@ -289,7 +289,7 @@ namespace {
       buffer[offset] = static_cast<uint8_t>(jlist_depth);
       offset += copied;
       byte_count += copied;
-      for (int i = 0; i < jlist_depth; i++) {
+      for (size_t i = 0; i < jlist_depth; i++) {
         copied = jlists[i].serialize(&buffer[offset]);
         offset += copied;
         byte_count += copied;
@@ -314,7 +314,7 @@ namespace {
         const size_t jlist_depth = buffer[offset];
         jlists.resize(jlist_depth);
         offset += copied;
-        for (int i = 0; i < jlist_depth; i++) {
+        for (size_t i = 0; i < jlist_depth; i++) {
           assert(offset < length);
           copied = jlists[i].deserialize(&buffer[offset], length - offset);
           offset += copied;

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -1,4 +1,4 @@
-#include <tree_sitter/parser.h>
+﻿#include <tree_sitter/parser.h>
 #include <cassert>
 #include <vector>
 #include <cstring>

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -1,0 +1,223 @@
+#ifndef TREE_SITTER_PARSER_H_
+#define TREE_SITTER_PARSER_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define ts_builtin_sym_error ((TSSymbol)-1)
+#define ts_builtin_sym_end 0
+#define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
+
+typedef uint16_t TSStateId;
+
+#ifndef TREE_SITTER_API_H_
+typedef uint16_t TSSymbol;
+typedef uint16_t TSFieldId;
+typedef struct TSLanguage TSLanguage;
+#endif
+
+typedef struct {
+  TSFieldId field_id;
+  uint8_t child_index;
+  bool inherited;
+} TSFieldMapEntry;
+
+typedef struct {
+  uint16_t index;
+  uint16_t length;
+} TSFieldMapSlice;
+
+typedef struct {
+  bool visible;
+  bool named;
+  bool supertype;
+} TSSymbolMetadata;
+
+typedef struct TSLexer TSLexer;
+
+struct TSLexer {
+  int32_t lookahead;
+  TSSymbol result_symbol;
+  void (*advance)(TSLexer *, bool);
+  void (*mark_end)(TSLexer *);
+  uint32_t (*get_column)(TSLexer *);
+  bool (*is_at_included_range_start)(const TSLexer *);
+  bool (*eof)(const TSLexer *);
+};
+
+typedef enum {
+  TSParseActionTypeShift,
+  TSParseActionTypeReduce,
+  TSParseActionTypeAccept,
+  TSParseActionTypeRecover,
+} TSParseActionType;
+
+typedef union {
+  struct {
+    uint8_t type;
+    TSStateId state;
+    bool extra;
+    bool repetition;
+  } shift;
+  struct {
+    uint8_t type;
+    uint8_t child_count;
+    TSSymbol symbol;
+    int16_t dynamic_precedence;
+    uint16_t production_id;
+  } reduce;
+  uint8_t type;
+} TSParseAction;
+
+typedef struct {
+  uint16_t lex_state;
+  uint16_t external_lex_state;
+} TSLexMode;
+
+typedef union {
+  TSParseAction action;
+  struct {
+    uint8_t count;
+    bool reusable;
+  } entry;
+} TSParseActionEntry;
+
+struct TSLanguage {
+  uint32_t version;
+  uint32_t symbol_count;
+  uint32_t alias_count;
+  uint32_t token_count;
+  uint32_t external_token_count;
+  uint32_t state_count;
+  uint32_t large_state_count;
+  uint32_t production_id_count;
+  uint32_t field_count;
+  uint16_t max_alias_sequence_length;
+  const uint16_t *parse_table;
+  const uint16_t *small_parse_table;
+  const uint32_t *small_parse_table_map;
+  const TSParseActionEntry *parse_actions;
+  const char * const *symbol_names;
+  const char * const *field_names;
+  const TSFieldMapSlice *field_map_slices;
+  const TSFieldMapEntry *field_map_entries;
+  const TSSymbolMetadata *symbol_metadata;
+  const TSSymbol *public_symbol_map;
+  const uint16_t *alias_map;
+  const TSSymbol *alias_sequences;
+  const TSLexMode *lex_modes;
+  bool (*lex_fn)(TSLexer *, TSStateId);
+  bool (*keyword_lex_fn)(TSLexer *, TSStateId);
+  TSSymbol keyword_capture_token;
+  struct {
+    const bool *states;
+    const TSSymbol *symbol_map;
+    void *(*create)(void);
+    void (*destroy)(void *);
+    bool (*scan)(void *, TSLexer *, const bool *symbol_whitelist);
+    unsigned (*serialize)(void *, char *);
+    void (*deserialize)(void *, const char *, unsigned);
+  } external_scanner;
+};
+
+/*
+ *  Lexer Macros
+ */
+
+#define START_LEXER()           \
+  bool result = false;          \
+  bool skip = false;            \
+  bool eof = false;             \
+  int32_t lookahead;            \
+  goto start;                   \
+  next_state:                   \
+  lexer->advance(lexer, skip);  \
+  start:                        \
+  skip = false;                 \
+  lookahead = lexer->lookahead;
+
+#define ADVANCE(state_value) \
+  {                          \
+    state = state_value;     \
+    goto next_state;         \
+  }
+
+#define SKIP(state_value) \
+  {                       \
+    skip = true;          \
+    state = state_value;  \
+    goto next_state;      \
+  }
+
+#define ACCEPT_TOKEN(symbol_value)     \
+  result = true;                       \
+  lexer->result_symbol = symbol_value; \
+  lexer->mark_end(lexer);
+
+#define END_STATE() return result;
+
+/*
+ *  Parse Table Macros
+ */
+
+#define SMALL_STATE(id) id - LARGE_STATE_COUNT
+
+#define STATE(id) id
+
+#define ACTIONS(id) id
+
+#define SHIFT(state_value)            \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .state = state_value            \
+    }                                 \
+  }}
+
+#define SHIFT_REPEAT(state_value)     \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .state = state_value,           \
+      .repetition = true              \
+    }                                 \
+  }}
+
+#define SHIFT_EXTRA()                 \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .extra = true                   \
+    }                                 \
+  }}
+
+#define REDUCE(symbol_val, child_count_val, ...) \
+  {{                                             \
+    .reduce = {                                  \
+      .type = TSParseActionTypeReduce,           \
+      .symbol = symbol_val,                      \
+      .child_count = child_count_val,            \
+      __VA_ARGS__                                \
+    },                                           \
+  }}
+
+#define RECOVER()                    \
+  {{                                 \
+    .type = TSParseActionTypeRecover \
+  }}
+
+#define ACCEPT_INPUT()              \
+  {{                                \
+    .type = TSParseActionTypeAccept \
+  }}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TREE_SITTER_PARSER_H_


### PR DESCRIPTION
CI enabled for Windows and Ubuntu
Fixed build of external scanner on Ubuntu
macOS build disabled until resolution of https://github.com/tree-sitter/tree-sitter/issues/1246
Added generated files to repo per https://github.com/tree-sitter/tree-sitter/discussions/1243
Fixed obscure BOM compilation issue on Windows as suggested in https://stackoverflow.com/a/27713211/2852699
