### PR TITLE
Attempt to check whether grammar & code are in sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
         run: node_modules/.bin/tree-sitter generate
       - name: Check grammar/code sync
         shell: bash
-        run: git status --porcelain=v1 2>/dev/null | wc -l
+        run: git status --porcelain=v1 2>/dev/null | wc -l | exit
       - name: Test
         run: node_modules/.bin/tree-sitter test
-  

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,6 @@ jobs:
       - name: Output2
         shell: bash
         run: git status --porcelain=v1 2>/dev/null | wc -l
-      - name: OutputTest
-        shell: bash
-        run: exit 1
       - name: Check grammar/code sync
         shell: bash
         # Command from https://stackoverflow.com/a/62768943/2852699

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Output2
         shell: bash
         run: git status --porcelain=v1 2>/dev/null | wc -l
+      - name: OutputTest
+        shell: bash
+        run: exit 0
       - name: Check grammar/code sync
         shell: bash
         # Command from https://stackoverflow.com/a/62768943/2852699

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
         run: node_modules/.bin/tree-sitter generate
       - name: Check grammar/code sync
         shell: bash
+        # Command from https://stackoverflow.com/a/62768943/2852699
         run: git status --porcelain=v1 2>/dev/null | wc -l | exit
       - name: Test
         run: node_modules/.bin/tree-sitter test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
       - name: Check grammar/code sync
         shell: bash
         # Command from https://stackoverflow.com/a/62768943/2852699
-        run: git status --porcelain=v1 2>/dev/null | wc -l | exit
+        run: |
+          diff_count=$(git status --porcelain=v1 2>/dev/null | wc -l)
+          exit $diff_count
       - name: Test
         run: node_modules/.bin/tree-sitter test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,11 @@ jobs:
         uses: actions/setup-node@v2
       - name: Build
         run: npm install
+      - name: Generate
+        run: node_modules/.bin/tree-sitter generate
+      - name: Check grammar/code sync
+        shell: bash
+        run: git status --porcelain=v1 2>/dev/null | wc -l
       - name: Test
         run: node_modules/.bin/tree-sitter test
   

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
         run: npm install
       - name: Generate
         run: node_modules/.bin/tree-sitter generate
+      - name: Renormalize line endings
+        shell: bash
+        run: git add --renormalize .
       - name: Output
         shell: bash
         run: git status --porcelain=v1 2>/dev/null
@@ -33,7 +36,7 @@ jobs:
         run: git status --porcelain=v1 2>/dev/null | wc -l
       - name: OutputTest
         shell: bash
-        run: exit 0
+        run: exit 1
       - name: Check grammar/code sync
         shell: bash
         # Command from https://stackoverflow.com/a/62768943/2852699

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,15 +28,12 @@ jobs:
       - name: Renormalize line endings
         shell: bash
         run: git add --renormalize .
-      - name: Output
+      - name: List changes
         shell: bash
-        run: git status --porcelain=v1 2>/dev/null
-      - name: Output2
-        shell: bash
-        run: git status --porcelain=v1 2>/dev/null | wc -l
+        run: git status
+        # Command from https://stackoverflow.com/a/62768943/2852699
       - name: Check grammar/code sync
         shell: bash
-        # Command from https://stackoverflow.com/a/62768943/2852699
         run: |
           diff_count=$(git status --porcelain=v1 2>/dev/null | wc -l)
           exit $diff_count

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,12 @@ jobs:
         run: npm install
       - name: Generate
         run: node_modules/.bin/tree-sitter generate
+      - name: Output
+        shell: bash
+        run: git status --porcelain=v1 2>/dev/null
+      - name: Output2
+        shell: bash
+        run: git status --porcelain=v1 2>/dev/null | wc -l
       - name: Check grammar/code sync
         shell: bash
         # Command from https://stackoverflow.com/a/62768943/2852699

--- a/grammar.js
+++ b/grammar.js
@@ -132,7 +132,7 @@ module.exports = grammar({
 
     // Top-level module declaration
     module: $ => seq(
-        $._single_line,
+        //$._single_line,
         'MODULE', field('name', $.identifier),
         $._single_line,
         optional($.extends),

--- a/grammar.js
+++ b/grammar.js
@@ -132,7 +132,7 @@ module.exports = grammar({
 
     // Top-level module declaration
     module: $ => seq(
-        //$._single_line,
+        $._single_line,
         'MODULE', field('name', $.identifier),
         $._single_line,
         optional($.extends),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -309,17 +309,8 @@
       "value": "@"
     },
     "label_as": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "::"
-        },
-        {
-          "type": "STRING",
-          "value": "∷"
-        }
-      ]
+      "type": "STRING",
+      "value": "::"
     },
     "placeholder": {
       "type": "STRING",
@@ -2035,18 +2026,6 @@
         {
           "type": "STRING",
           "value": "BOOLEAN"
-        },
-        {
-          "type": "STRING",
-          "value": "Nat"
-        },
-        {
-          "type": "STRING",
-          "value": "Int"
-        },
-        {
-          "type": "STRING",
-          "value": "Real"
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -4786,11 +4786,6 @@
     }
   },
   {
-    "type": "label_as",
-    "named": true,
-    "fields": {}
-  },
-  {
     "type": "lambda",
     "named": true,
     "fields": {},
@@ -9597,10 +9592,6 @@
     "named": false
   },
   {
-    "type": "::",
-    "named": false
-  },
-  {
     "type": "::=",
     "named": false
   },
@@ -9765,10 +9756,6 @@
     "named": false
   },
   {
-    "type": "Int",
-    "named": false
-  },
-  {
     "type": "LAMBDA",
     "named": false
   },
@@ -9790,10 +9777,6 @@
   },
   {
     "type": "NEW",
-    "named": false
-  },
-  {
-    "type": "Nat",
     "named": false
   },
   {
@@ -9834,10 +9817,6 @@
   },
   {
     "type": "RECURSIVE",
-    "named": false
-  },
-  {
-    "type": "Real",
     "named": false
   },
   {
@@ -10209,6 +10188,10 @@
     "named": true
   },
   {
+    "type": "label_as",
+    "named": true
+  },
+  {
     "type": "lt",
     "named": true
   },
@@ -10426,10 +10409,6 @@
   },
   {
     "type": "∪",
-    "named": false
-  },
-  {
-    "type": "∷",
     "named": false
   },
   {


### PR DESCRIPTION
Having already been bitten by my grammar & generated code being out of sync from the very first time they were committed to the repo, this adds a check to the CI workflow to test whether running `tree-sitter generate` results in any changes to the generated files; if so, pull request merges will be blocked.