### PR TITLE
Moved external scanner fully to generalized token lookahead system

### DIFF
--- a/test/corpus/conjlist.txt
+++ b/test/corpus/conjlist.txt
@@ -569,6 +569,11 @@ op5 ==
   /\ 9
   /\ 10
       VARIABLES x, y
+
+op6 ==
+  /\ 11
+  /\ 12
+      INSTANCE ModuleName
 ====
 
 -------------|||
@@ -614,6 +619,14 @@ op5 ==
     )
   ))
   (unit (variable_declaration (identifier) (identifier)))
+  (unit (operator_definition
+    (identifier) (def_eq)
+    (conj_list
+      (conj_item (bullet_conj) (number (nat_number)))
+      (conj_item (bullet_conj) (number (nat_number)))
+    )
+  ))
+  (unit (instance (identifier)))
 (double_line)))
 
 =============|||


### PR DESCRIPTION
This avoids having to special-case instances of two tokens having the same start character.
Further improves https://github.com/tlaplus-community/tree-sitter-tlaplus/issues/3