### PR TITLE
Correctly parse all specs in the Examples repo

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -206,6 +206,7 @@ module.exports = grammar({
         $.variable_declaration,
         $.constant_declaration,
         $.recursive_declaration,
+        $.use_or_hide,
         seq(optional("LOCAL"), $.operator_definition),
         seq(optional("LOCAL"), $.function_definition),
         seq(optional("LOCAL"), $.instance),

--- a/grammar.js
+++ b/grammar.js
@@ -151,25 +151,26 @@ module.exports = grammar({
     double_line: $ => /=====*/,
 
     // Various syntactic elements and their unicode equivalents
-    def_eq:           $ => choice('==', '≜'),
-    set_in:           $ => choice('\\in', '∈'),
-    gets:             $ => choice('<-', '⟵'),
-    forall:           $ => choice('\\A', '\\forall', '∀'),
-    exists:           $ => choice('\\E', '\\exists', '∃'),
-    temporal_forall:  $ => choice('\\AA'),
-    temporal_exists:  $ => choice('\\EE'),
-    all_map_to:       $ => choice('|->', '⟼'), 
-    maps_to:          $ => choice('->', '⟶'),
-    langle_bracket:   $ => choice('<<', '〈'),
-    rangle_bracket:   $ => choice('>>', '〉'),
-    case_box:         $ => choice('[]', '□'),
-    case_arrow:       $ => choice('->', '⟶'),
-    bullet_conj:      $ => choice('/\\', '∧'),
-    bullet_disj:      $ => choice('\\/', '∨'),
-    colon:            $ => ':',
-    address:          $ => '@',
-    label_as:         $ => choice('::', '∷'),
-    placeholder:      $ => '_',
+    def_eq:             $ => choice('==', '≜'),
+    set_in:             $ => choice('\\in', '∈'),
+    gets:               $ => choice('<-', '⟵'),
+    forall:             $ => choice('\\A', '\\forall', '∀'),
+    exists:             $ => choice('\\E', '\\exists', '∃'),
+    temporal_forall:    $ => choice('\\AA'),
+    temporal_exists:    $ => choice('\\EE'),
+    all_map_to:         $ => choice('|->', '⟼'), 
+    maps_to:            $ => choice('->', '⟶'),
+    langle_bracket:     $ => choice('<<', '〈'),
+    rangle_bracket:     $ => choice('>>', '〉'),
+    rangle_bracket_sub: $ => choice('>>_', '〉_'),
+    case_box:           $ => choice('[]', '□'),
+    case_arrow:         $ => choice('->', '⟶'),
+    bullet_conj:        $ => choice('/\\', '∧'),
+    bullet_disj:        $ => choice('\\/', '∨'),
+    colon:              $ => ':',
+    address:            $ => '@',
+    label_as:           $ => choice('::', '∷'),
+    placeholder:        $ => '_',
 
     // The set of all reserved keywords
     keyword: $ => choice(
@@ -477,7 +478,7 @@ module.exports = grammar({
     _hex_number: $ => /(\\h|\\H)[0-9a-fA-F]+/,
 
     // "foobar", "", etc.
-    string: $ => /"([^"]|\\")*"/,
+    string: $ => /"([^"\\]|\\\\|\\")*"/,
 
     // TRUE, FALSE, BOOLEAN
     boolean: $ => choice('TRUE', 'FALSE'),
@@ -621,7 +622,7 @@ module.exports = grammar({
     step_expr_no_stutter: $ => seq(
       $.langle_bracket,
       $._expr,
-      $.rangle_bracket, token.immediate('_'),
+      $.rangle_bracket_sub,
       $._subscript_expr
     ),
 
@@ -703,6 +704,7 @@ module.exports = grammar({
     powerset:         $ => 'SUBSET',
     domain:           $ => 'DOMAIN',
     negative:         $ => '-',
+    negative_dot:     $ => '-.',
     enabled:          $ => 'ENABLED',
     unchanged:        $ => 'UNCHANGED',
     always:           $ => choice('[]', '□'),
@@ -717,7 +719,7 @@ module.exports = grammar({
     // Negative is disambiguated from minus with a '.'
     standalone_prefix_op_symbol: $ => choice(
       $._prefix_op_symbol_except_negative,
-      seq($.negative, token.immediate('.'))
+      $.negative_dot
     ),
 
     // All bound prefix operators
@@ -778,8 +780,8 @@ module.exports = grammar({
     map_to:           $ => ':>',
     map_from:         $ => '<:',
     setminus:         $ => '\\',
-    cap:              $ => choice('\\cap', '∩'),
-    cup:              $ => choice('\\cup', '∪'),
+    cap:              $ => choice('\\cap', '\\intersect', '∩'),
+    cup:              $ => choice('\\cup', '\\union', '∪'),
     dots_2:           $ => choice('..', '‥'),
     dots_3:           $ => choice('...', '…'),
     plus:             $ => '+',
@@ -804,7 +806,7 @@ module.exports = grammar({
     bigcirc:          $ => choice('\\bigcirc', '◯'),
     bullet:           $ => choice('\\bullet', '●'),
     div:              $ => choice('\\div', '÷'),
-    circ:             $ => choice('\\circ', '∘'),
+    circ:             $ => choice('\\o', '\\circ', '∘'),
     star:             $ => choice('\\star', '⋆'),
     excl:             $ => choice('!!', '‼'),
     qq:               $ => choice('??', '⁇'),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -265,6 +265,19 @@
         }
       ]
     },
+    "rangle_bracket_sub": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": ">>_"
+        },
+        {
+          "type": "STRING",
+          "value": "〉_"
+        }
+      ]
+    },
     "case_box": {
       "type": "CHOICE",
       "members": [
@@ -2060,7 +2073,7 @@
     },
     "string": {
       "type": "PATTERN",
-      "value": "\"([^\"]|\\\\\")*\""
+      "value": "\"([^\"\\\\]|\\\\\\\\|\\\\\")*\""
     },
     "boolean": {
       "type": "CHOICE",
@@ -3017,14 +3030,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "rangle_bracket"
-        },
-        {
-          "type": "IMMEDIATE_TOKEN",
-          "content": {
-            "type": "STRING",
-            "value": "_"
-          }
+          "name": "rangle_bracket_sub"
         },
         {
           "type": "SYMBOL",
@@ -3373,6 +3379,10 @@
       "type": "STRING",
       "value": "-"
     },
+    "negative_dot": {
+      "type": "STRING",
+      "value": "-."
+    },
     "enabled": {
       "type": "STRING",
       "value": "ENABLED"
@@ -3452,20 +3462,8 @@
           "name": "_prefix_op_symbol_except_negative"
         },
         {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "negative"
-            },
-            {
-              "type": "IMMEDIATE_TOKEN",
-              "content": {
-                "type": "STRING",
-                "value": "."
-              }
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "negative_dot"
         }
       ]
     },
@@ -4193,6 +4191,10 @@
         },
         {
           "type": "STRING",
+          "value": "\\intersect"
+        },
+        {
+          "type": "STRING",
           "value": "∩"
         }
       ]
@@ -4203,6 +4205,10 @@
         {
           "type": "STRING",
           "value": "\\cup"
+        },
+        {
+          "type": "STRING",
+          "value": "\\union"
         },
         {
           "type": "STRING",
@@ -4428,6 +4434,10 @@
     "circ": {
       "type": "CHOICE",
       "members": [
+        {
+          "type": "STRING",
+          "value": "\\o"
+        },
         {
           "type": "STRING",
           "value": "\\circ"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -634,6 +634,10 @@
           "name": "recursive_declaration"
         },
         {
+          "type": "SYMBOL",
+          "name": "use_or_hide"
+        },
+        {
           "type": "SEQ",
           "members": [
             {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -10407,6 +10407,10 @@
           "named": true
         },
         {
+          "type": "use_or_hide",
+          "named": true
+        },
+        {
           "type": "variable_declaration",
           "named": true
         }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -7563,6 +7563,11 @@
     "fields": {}
   },
   {
+    "type": "rangle_bracket_sub",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "rd_ttile",
     "named": true,
     "fields": {}
@@ -8867,7 +8872,7 @@
           "named": true
         },
         {
-          "type": "negative",
+          "type": "negative_dot",
           "named": true
         },
         {
@@ -9007,7 +9012,7 @@
           "named": true
         },
         {
-          "type": "rangle_bracket",
+          "type": "rangle_bracket_sub",
           "named": true
         },
         {
@@ -11130,6 +11135,10 @@
     "named": false
   },
   {
+    "type": ">>_",
+    "named": false
+  },
+  {
     "type": "??",
     "named": false
   },
@@ -11486,6 +11495,10 @@
     "named": false
   },
   {
+    "type": "\\intersect",
+    "named": false
+  },
+  {
     "type": "\\land",
     "named": false
   },
@@ -11511,6 +11524,10 @@
   },
   {
     "type": "\\notin",
+    "named": false
+  },
+  {
+    "type": "\\o",
     "named": false
   },
   {
@@ -11610,6 +11627,10 @@
     "named": false
   },
   {
+    "type": "\\union",
+    "named": false
+  },
+  {
     "type": "\\uplus",
     "named": false
   },
@@ -11627,10 +11648,6 @@
   },
   {
     "type": "^+",
-    "named": false
-  },
-  {
-    "type": "_",
     "named": false
   },
   {
@@ -11715,6 +11732,10 @@
   },
   {
     "type": "mulmul",
+    "named": true
+  },
+  {
+    "type": "negative_dot",
     "named": true
   },
   {
@@ -12103,6 +12124,10 @@
   },
   {
     "type": "〉",
+    "named": false
+  },
+  {
+    "type": "〉_",
     "named": false
   }
 ]

--- a/test/corpus/operators.txt
+++ b/test/corpus/operators.txt
@@ -1,0 +1,27 @@
+=============|||
+Odd Alternative Operators
+=============|||
+
+---- MODULE Test ----
+alt_leq == a =< b
+alt_cup == a \union b
+alt_cap == a \intersect b
+alt_circ == a \o b
+====
+
+--------------|||
+
+(source_file (module (single_line) (identifier) (single_line)
+  (unit (operator_definition (identifier) (def_eq)
+    (bound_infix_op (identifier) (leq) (identifier))
+  ))
+  (unit (operator_definition (identifier) (def_eq)
+    (bound_infix_op (identifier) (cup) (identifier))
+  ))
+  (unit (operator_definition (identifier) (def_eq)
+    (bound_infix_op (identifier) (cap) (identifier))
+  ))
+  (unit (operator_definition (identifier) (def_eq)
+    (bound_infix_op (identifier) (circ) (identifier))
+  ))
+(double_line)))

--- a/test/corpus/step_expressions.txt
+++ b/test/corpus/step_expressions.txt
@@ -1,0 +1,35 @@
+=============|||
+Step Expression Or Stuttering
+=============|||
+
+---- MODULE Test ----
+op == [A]_B
+====
+
+--------------|||
+
+(source_file (module (single_line) (identifier) (single_line)
+  (unit (operator_definition
+    (identifier) (def_eq)
+    (step_expr_or_stutter (identifier) (identifier))
+  ))
+(double_line)))
+
+=============|||
+Step Expression No Stuttering
+=============|||
+
+---- MODULE Test ----
+op == <<A>>_B
+====
+
+--------------|||
+
+(source_file (module (single_line) (identifier) (single_line)
+  (unit (operator_definition
+    (identifier) (def_eq)
+    (step_expr_no_stutter
+      (langle_bracket) (identifier) (rangle_bracket_sub) (identifier)
+    )
+  ))
+(double_line)))

--- a/test/corpus/string.txt
+++ b/test/corpus/string.txt
@@ -45,3 +45,23 @@ op == "加拿大"
     (identifier) (def_eq) (string)
   ))
 (double_line)))
+
+==================|||
+Escape Escape String
+==================|||
+
+---- MODULE Test ----
+op == <<"/\\", "\\/">>
+====
+
+------------------|||
+
+(source_file (module (single_line) (identifier) (single_line)
+  (unit (operator_definition (identifier) (def_eq)
+    (tuple_literal (langle_bracket) (string) (string) (rangle_bracket))
+  ))
+(double_line)))
+
+
+
+


### PR DESCRIPTION
- Added missing operators \o, \union, and \intersect
- Fixed string regex to handle escape-backslash
- Fix lexing priority of >>_ and -.
- Added use-or-hide to unit-level definitions