### PR TITLE
Check that generated file tree-sitter-tlaplus.wasm is current in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,28 +23,8 @@ jobs:
           submodules: recursive
       - name: Install node
         uses: actions/setup-node@v2
-      - name: Install Emscripten
-        uses: mymindstorm/setup-emsdk@v10
-        with:
-          version: 2.0.16
-      - name: Verify Emscripten install
-        run: emcc -v
       - name: Build
         run: npm install
-      - name: Generate
-        run: node_modules/.bin/tree-sitter generate
-      - name: Renormalize line endings
-        shell: bash
-        run: git add --renormalize .
-      - name: List changes
-        shell: bash
-        run: git status
-        # Command from https://stackoverflow.com/a/62768943/2852699
-      - name: Check grammar/code sync
-        shell: bash
-        run: |
-          diff_count=$(git status --porcelain=v1 2>/dev/null | wc -l)
-          exit $diff_count
       - name: Unit Tests
         run: node_modules/.bin/tree-sitter test
       - name: Corpus Tests
@@ -59,3 +39,26 @@ jobs:
           $failures = $specs.FullName |% {node_modules/.bin/tree-sitter parse -q $_}
           $failures
           exit $failures.length
+      - name: Generate parser code
+        run: node_modules/.bin/tree-sitter generate
+      - name: Install Emscripten
+        uses: mymindstorm/setup-emsdk@v10
+        with:
+          version: 2.0.16
+      - name: Generate parser WASM
+        run: node_modules/.bin/tree-sitter build-wasm
+      - name: Move parser WASM
+        shell: bash
+        run: mv tree-sitter-tlaplus.wasm ./docs/js/tree-sitter-tlaplus.wasm
+      - name: Renormalize line endings
+        shell: bash
+        run: git add --renormalize .
+      - name: List changes
+        shell: bash
+        run: git status
+        # Command from https://stackoverflow.com/a/62768943/2852699
+      - name: Check grammar/code sync
+        shell: bash
+        run: |
+          diff_count=$(git status --porcelain=v1 2>/dev/null | wc -l)
+          exit $diff_count

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,12 @@ jobs:
           submodules: recursive
       - name: Install node
         uses: actions/setup-node@v2
+      - name: Install Emscripten
+        uses: mymindstorm/setup-emsdk@v10
+        with:
+          version: 2.0.16
+      - name: Verify Emscripten install
+        run: emcc -v
       - name: Build
         run: npm install
       - name: Generate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,9 @@ jobs:
             -Filter "*.tla" `
             -Exclude "Reals.tla","Naturals.tla" `
             -Recurse
-          $specs.FullName
+          Push-Location .\test\examples\external\specifications
+          $specs | Resolve-Path -Relative
+          Pop-Location
           $failures = $specs.FullName |% {node_modules/.bin/tree-sitter parse -q $_}
           $failures
           exit $failures.length

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,18 +36,22 @@ jobs:
             -Filter "*.tla" `
             -Exclude "Reals.tla","Naturals.tla" `
             -Recurse
+          $specs
           $failures = $specs.FullName |% {node_modules/.bin/tree-sitter parse -q $_}
           $failures
           exit $failures.length
       - name: Generate parser code
         run: node_modules/.bin/tree-sitter generate
       - name: Install Emscripten
+        if: runner.os == 'Windows'
         uses: mymindstorm/setup-emsdk@v10
         with:
           version: 2.0.16
       - name: Generate parser WASM
+        if: runner.os == 'Windows'
         run: node_modules/.bin/tree-sitter build-wasm
       - name: Move parser WASM
+        if: runner.os == 'Windows'
         shell: bash
         run: mv tree-sitter-tlaplus.wasm ./docs/js/tree-sitter-tlaplus.wasm
       - name: Renormalize line endings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
             -Filter "*.tla" `
             -Exclude "Reals.tla","Naturals.tla" `
             -Recurse
-          $specs
+          $specs.FullName
           $failures = $specs.FullName |% {node_modules/.bin/tree-sitter parse -q $_}
           $failures
           exit $failures.length


### PR DESCRIPTION
Validates that the generated file `docs/js/tree-sitter-tlaplus.wasm` is current
Uses Emscripten 2.0.16 on Windows
Improved corpus test output with list of files
Fixes #26 