### PR TITLE
Added unicode symbol alternatives

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -182,18 +182,18 @@ module.exports = grammar({
     // Various syntactic elements and their unicode equivalents
     def_eq:             $ => choice('==', '≜'),
     set_in:             $ => choice('\\in', '∈'),
-    gets:               $ => choice('<-', '⟵'),
+    gets:               $ => choice('<-', '⟵', '←'),
     forall:             $ => choice('\\A', '\\forall', '∀'),
     exists:             $ => choice('\\E', '\\exists', '∃'),
     temporal_forall:    $ => choice('\\AA'),
     temporal_exists:    $ => choice('\\EE'),
-    all_map_to:         $ => choice('|->', '⟼'), 
-    maps_to:            $ => choice('->', '⟶'),
-    langle_bracket:     $ => choice('<<', '〈'),
-    rangle_bracket:     $ => choice('>>', '〉'),
-    rangle_bracket_sub: $ => choice('>>_', '〉_'),
+    all_map_to:         $ => choice('|->', '⟼', '↦'), 
+    maps_to:            $ => choice('->', '⟶', '→'),
+    langle_bracket:     $ => choice('<<', '〈', '⟨'),
+    rangle_bracket:     $ => choice('>>', '〉', '⟩'),
+    rangle_bracket_sub: $ => choice('>>_', '〉_', '⟩_'),
     case_box:           $ => choice('[]', '□'),
-    case_arrow:         $ => choice('->', '⟶'),
+    case_arrow:         $ => choice('->', '⟶', '→'),
     colon:              $ => ':',
     address:            $ => '@',
     label_as:           $ => choice('::', '∷'),
@@ -810,11 +810,11 @@ module.exports = grammar({
     ),
 
     // Infix operator symbols and their unicode equivalents.
-    implies:          $ => choice('=>', '⟹'),
-    plus_arrow:       $ => choice('-+->', '⇸'),
+    implies:          $ => choice('=>', '⟹', '⇒'),
+    plus_arrow:       $ => choice('-+->', '⇸', '⥅'),
     equiv:            $ => choice('\\equiv', '≡'),
-    iff:              $ => choice('<=>', '⟺'),
-    leads_to:         $ => choice('~>', '⇝'),
+    iff:              $ => choice('<=>', '⟺', '⇔'),
+    leads_to:         $ => choice('~>', '⇝', '↝'),
     land:             $ => choice('/\\', '\\land', '∧'),
     lor:              $ => choice('\\/', '\\lor', '∨'),
     assign:           $ => choice(':=', '≔'),
@@ -979,7 +979,8 @@ module.exports = grammar({
     // All bound postfix operators.
     // Precedence defined on p271 of Specifying Systems.
     bound_postfix_op: $ => choice(
-      postfixOpPrec('15-15', $._expr, $.postfix_op_symbol)
+      postfixOpPrec('15-15', $._expr, choice(
+        $.sup_plus, $.asterisk, $.sup_hash, $.prime))
     ),
 
     /************************************************************************/

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -162,6 +162,10 @@
         {
           "type": "STRING",
           "value": "⟵"
+        },
+        {
+          "type": "STRING",
+          "value": "←"
         }
       ]
     },
@@ -227,6 +231,10 @@
         {
           "type": "STRING",
           "value": "⟼"
+        },
+        {
+          "type": "STRING",
+          "value": "↦"
         }
       ]
     },
@@ -240,6 +248,10 @@
         {
           "type": "STRING",
           "value": "⟶"
+        },
+        {
+          "type": "STRING",
+          "value": "→"
         }
       ]
     },
@@ -253,6 +265,10 @@
         {
           "type": "STRING",
           "value": "〈"
+        },
+        {
+          "type": "STRING",
+          "value": "⟨"
         }
       ]
     },
@@ -266,6 +282,10 @@
         {
           "type": "STRING",
           "value": "〉"
+        },
+        {
+          "type": "STRING",
+          "value": "⟩"
         }
       ]
     },
@@ -279,6 +299,10 @@
         {
           "type": "STRING",
           "value": "〉_"
+        },
+        {
+          "type": "STRING",
+          "value": "⟩_"
         }
       ]
     },
@@ -305,6 +329,10 @@
         {
           "type": "STRING",
           "value": "⟶"
+        },
+        {
+          "type": "STRING",
+          "value": "→"
         }
       ]
     },
@@ -3824,6 +3852,10 @@
         {
           "type": "STRING",
           "value": "⟹"
+        },
+        {
+          "type": "STRING",
+          "value": "⇒"
         }
       ]
     },
@@ -3837,6 +3869,10 @@
         {
           "type": "STRING",
           "value": "⇸"
+        },
+        {
+          "type": "STRING",
+          "value": "⥅"
         }
       ]
     },
@@ -3863,6 +3899,10 @@
         {
           "type": "STRING",
           "value": "⟺"
+        },
+        {
+          "type": "STRING",
+          "value": "⇔"
         }
       ]
     },
@@ -3876,6 +3916,10 @@
         {
           "type": "STRING",
           "value": "⇝"
+        },
+        {
+          "type": "STRING",
+          "value": "↝"
         }
       ]
     },
@@ -5927,8 +5971,25 @@
                 "type": "FIELD",
                 "name": "symbol",
                 "content": {
-                  "type": "SYMBOL",
-                  "name": "postfix_op_symbol"
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "sup_plus"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "asterisk"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "sup_hash"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "prime"
+                    }
+                  ]
                 }
               }
             ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -863,7 +863,19 @@
         "required": true,
         "types": [
           {
-            "type": "postfix_op_symbol",
+            "type": "asterisk",
+            "named": true
+          },
+          {
+            "type": "prime",
+            "named": true
+          },
+          {
+            "type": "sup_hash",
+            "named": true
+          },
+          {
+            "type": "sup_plus",
             "named": true
           }
         ]
@@ -4557,6 +4569,30 @@
     "named": false
   },
   {
+    "type": "←",
+    "named": false
+  },
+  {
+    "type": "→",
+    "named": false
+  },
+  {
+    "type": "↝",
+    "named": false
+  },
+  {
+    "type": "↦",
+    "named": false
+  },
+  {
+    "type": "⇒",
+    "named": false
+  },
+  {
+    "type": "⇔",
+    "named": false
+  },
+  {
     "type": "⇝",
     "named": false
   },
@@ -4777,6 +4813,18 @@
     "named": false
   },
   {
+    "type": "⟨",
+    "named": false
+  },
+  {
+    "type": "⟩",
+    "named": false
+  },
+  {
+    "type": "⟩_",
+    "named": false
+  },
+  {
     "type": "⟵",
     "named": false
   },
@@ -4794,6 +4842,10 @@
   },
   {
     "type": "⟼",
+    "named": false
+  },
+  {
+    "type": "⥅",
     "named": false
   },
   {


### PR DESCRIPTION
Added support for alternative Unicode symbols. Since this grammar is intended to be permissive by design, it's okay if we accept certain unicode symbols even if they don't end up in [the standard](https://github.com/tlaplus-community/tlaplus-standard/tree/main/unicode).