### PR TITLE
Fixed jlist unicode issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "nan": "^2.14.2"
   },
   "devDependencies": {
-    "@tlaplus/tree-sitter-cli": "^0.20.1-0"
+    "@tlaplus/tree-sitter-cli": "^0.20.1-1"
   },
   "tree-sitter": [
     {

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -514,6 +514,7 @@ namespace {
         if (L'∧' == lookahead) ADVANCE(LexState_LAND);
         if (L'∨' == lookahead) ADVANCE(LexState_LOR);
         if (L'〉' == lookahead) ADVANCE(LexState_R_ANGLE_BRACKET);
+        if (L'⟩' == lookahead) ADVANCE(LexState_R_ANGLE_BRACKET);
         if (L'⟶' == lookahead) ADVANCE(LexState_RIGHT_ARROW);
         ADVANCE(LexState_OTHER);
         END_LEX_STATE();

--- a/test/corpus/conjlist-unicode.txt
+++ b/test/corpus/conjlist-unicode.txt
@@ -1,0 +1,634 @@
+=============|||
+Basic Unicode Conjlist
+=============|||
+
+---- MODULE Test ----
+op ≜
+    ∧ 1
+    ∧ 2
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (conj_list
+      (conj_item (bullet_conj) (nat_number))
+      (conj_item (bullet_conj) (nat_number))
+    )
+  )
+(double_line)))
+
+=============|||
+Inline Unicode Conjlist
+=============|||
+
+---- MODULE Test ----
+op ≜ ∧ 1
+     ∧ 2
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (conj_list
+      (conj_item (bullet_conj) (nat_number))
+      (conj_item (bullet_conj) (nat_number))
+    )
+  )
+(double_line)))
+
+=============|||
+Start-of-Line Unicode Conjlist
+=============|||
+
+---- MODULE Test ----
+op ≜
+∧ 1
+∧ 2
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (conj_list
+      (conj_item (bullet_conj) (nat_number))
+      (conj_item (bullet_conj) (nat_number))
+    )
+  )
+(double_line)))
+
+=============|||
+Left-Shifted Unicode Conjlist
+=============|||
+
+---- MODULE Test ----
+op ≜
+ ∧ 1
+∧ 2
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (bound_infix_op
+      (conj_list (conj_item (bullet_conj) (nat_number)))
+      (land)
+      (nat_number)
+    )
+  )
+(double_line)))
+
+=============|||
+Right-Shifted Unicode Conjlist
+=============|||
+
+---- MODULE Test ----
+op ≜
+∧ 1
+ ∧ 2
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (conj_list
+      (conj_item
+        (bullet_conj)
+        (bound_infix_op
+          (nat_number)
+          (land)
+          (nat_number)
+        )
+      )
+    )
+  )
+(double_line)))
+
+=============|||
+Separated Unicode Conjlist
+=============|||
+
+---- MODULE Test ----
+op ≜
+  ∧ 1
+
+  ∧ 2
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (conj_list
+      (conj_item (bullet_conj) (nat_number))
+      (conj_item (bullet_conj) (nat_number))
+    )
+  )
+(double_line)))
+
+=============|||
+Multiline Unicode Conjlist
+=============|||
+
+---- MODULE Test ----
+op ≜
+  ∧ 
+   1
+  ∧
+   2
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (conj_list
+      (conj_item (bullet_conj) (nat_number))
+      (conj_item (bullet_conj) (nat_number))
+    )
+  )
+(double_line)))
+
+=============|||
+Nested Unicode Conjlist
+=============|||
+
+---- MODULE Test ----
+op ≜
+ ∧ ∧ 1
+   ∧ 2
+ ∧ 3
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (conj_list
+      (conj_item
+        (bullet_conj)
+        (conj_list
+          (conj_item (bullet_conj) (nat_number))
+          (conj_item (bullet_conj) (nat_number))
+        )
+      )
+      (conj_item (bullet_conj) (nat_number))
+    )
+  )
+(double_line)))
+
+=============|||
+Start-of-Line Nested Unicode Conjlist
+=============|||
+
+---- MODULE Test ----
+op ≜
+∧ ∧ 1
+  ∧ 2
+∧ 3
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (conj_list
+      (conj_item (bullet_conj)
+        (conj_list
+          (conj_item (bullet_conj) (nat_number))
+          (conj_item (bullet_conj) (nat_number))
+        )
+      )
+      (conj_item (bullet_conj) (nat_number))
+    )
+  )
+(double_line)))
+
+=============|||
+Infix Op Unicode Conjlist
+=============|||
+
+---- MODULE Test ----
+op ≜
+ ∧ 1
+  + 2 
+ ∧ 3
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (conj_list
+      (conj_item
+        (bullet_conj)
+        (bound_infix_op
+          (nat_number)
+          (plus)
+          (nat_number)
+        )
+      )
+      (conj_item (bullet_conj) (nat_number))
+    )
+  )
+(double_line)))
+
+=============|||
+Division Infix Op Unicode Conjlist
+=============|||
+
+---- MODULE Test ----
+op ≜
+ ∧ 1
+  / 2 
+ ∧ 3
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (conj_list
+      (conj_item
+        (bullet_conj)
+        (bound_infix_op
+          (nat_number)
+          (slash)
+          (nat_number)
+        )
+      )
+      (conj_item (bullet_conj) (nat_number))
+    )
+  )
+(double_line)))
+
+=============|||
+Infix Op Terminated Unicode Conjlist
+=============|||
+
+---- MODULE Test ----
+op ≜
+ ∧ 1
+ + 2 
+ ∧ 3
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (bound_infix_op
+      (bound_infix_op
+        (conj_list (conj_item (bullet_conj) (nat_number)))
+        (plus)
+        (nat_number)
+      )
+      (land)
+      (nat_number)
+    )
+  )
+(double_line)))
+
+=============|||
+Division Infix Op Terminated Unicode Conjlist
+=============|||
+
+---- MODULE Test ----
+op ≜
+ ∧ 1
+ / 2 
+ ∧ 3
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (bound_infix_op
+      (bound_infix_op
+        (conj_list (conj_item (bullet_conj) (nat_number)))
+        (slash)
+        (nat_number)
+      )
+      (land)
+      (nat_number)
+    )
+  )
+(double_line)))
+
+=============|||
+Not a Unicode Conjlist
+=============|||
+
+---- MODULE Test ----
+op ≜ 1 ∧ 2
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (bound_infix_op
+      (nat_number)
+      (land)
+      (nat_number)
+    )
+  )
+(double_line)))
+
+=============|||
+Unicode Conjlist with Parentheses
+=============|||
+
+---- MODULE Test ----
+op ≜
+  ∧ (1)
+  ∧ (2)
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (conj_list
+      (conj_item (bullet_conj) (parentheses (nat_number)))
+      (conj_item (bullet_conj) (parentheses (nat_number)))
+    )
+  )
+(double_line)))
+
+=============|||
+Unicode Conjlist Terminated by Parentheses
+=============|||
+
+---- MODULE Test ----
+op ≜ (
+  ∧ 1
+   )
+  ∧ 2
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (bound_infix_op
+      (parentheses
+        (conj_list (conj_item (bullet_conj) (nat_number)))
+      )
+      (land)
+      (nat_number)
+    )
+  )
+(double_line)))
+
+=============|||
+Nested Unicode Conjlist Terminated by Parentheses
+=============|||
+
+---- MODULE Test ----
+op ≜ (
+  ∧ 1
+  ∧  ∧ 2
+     ∧ 3
+       )
+  ∧ 4
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (bound_infix_op
+      (parentheses
+        (conj_list
+          (conj_item (bullet_conj) (nat_number))
+          (conj_item
+            (bullet_conj)
+            (conj_list
+              (conj_item (bullet_conj) (nat_number))
+              (conj_item (bullet_conj) (nat_number))
+            )
+          )
+        )
+      )
+      (land)
+      (nat_number)
+    )
+  )
+(double_line)))
+
+=============|||
+Double-Nested Unicode Conjlist Terminated by Parentheses
+=============|||
+
+---- MODULE Test ----
+op ≜
+  ∧ 1
+  ∧  ∧ 2 + (
+        ∧ 3
+        ∧ 4
+          )
+     ∧ 5
+  ∧ 6
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (conj_list
+      (conj_item (bullet_conj) (nat_number))
+      (conj_item
+        (bullet_conj)
+        (conj_list
+          (conj_item
+            (bullet_conj)
+            (bound_infix_op
+              (nat_number)
+              (plus)
+              (parentheses
+                (conj_list
+                  (conj_item (bullet_conj) (nat_number))
+                  (conj_item (bullet_conj) (nat_number))
+                )
+              )
+            )
+          )
+          (conj_item (bullet_conj) (nat_number))
+        )
+      )
+      (conj_item (bullet_conj) (nat_number))
+    )
+  )
+(double_line)))
+
+=============|||
+Overly-Permissive Unicode Conjlist Parentheses Parsing
+=============|||
+
+---- MODULE Test ----
+op ≜
+  ∧ 1
+  ∧ (2 + 3
+)
+  ∧ 4
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (conj_list
+      (conj_item (bullet_conj) (nat_number))
+      (conj_item
+        (bullet_conj)
+        (parentheses
+          (bound_infix_op
+            (nat_number) (plus) (nat_number)
+          )
+        )
+      )
+      (conj_item (bullet_conj) (nat_number))
+    )
+  )
+(double_line)))
+
+=============|||
+Module-End-Terminated Unicode Conjlist
+=============|||
+
+---- MODULE Test ----
+op ≜
+  ∧ 1
+  ∧ 2  ====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (conj_list
+      (conj_item (bullet_conj) (nat_number))
+      (conj_item (bullet_conj) (nat_number))
+    )
+  )
+(double_line)))
+
+=============|||
+Keyword-Unit-Terminated Unicode Conjlist
+=============|||
+
+---- MODULE Test ----
+op1 ≜
+  ∧ 1
+  ∧ 2
+      ASSUME x
+
+op2 ≜
+  ∧ 3
+  ∧ 4
+      LOCAL INSTANCE ModuleName
+
+op3 ≜
+  ∧ 5
+  ∧ 6
+      -----------------
+
+op4 ≜
+  ∧ 7
+  ∧ 8
+      ---- MODULE Nested ----
+      ====
+
+op5 ≜
+  ∧ 9
+  ∧ 10
+      VARIABLES x, y
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (conj_list
+      (conj_item (bullet_conj) (nat_number))
+      (conj_item (bullet_conj) (nat_number))
+    )
+  )
+  (assumption (identifier_ref))
+  (operator_definition (identifier) (def_eq)
+    (conj_list
+      (conj_item (bullet_conj) (nat_number))
+      (conj_item (bullet_conj) (nat_number))
+    )
+  )
+  (local_definition (instance (identifier_ref)))
+  (operator_definition (identifier) (def_eq)
+    (conj_list
+      (conj_item (bullet_conj) (nat_number))
+      (conj_item (bullet_conj) (nat_number))
+    )
+  )
+  (single_line)
+  (operator_definition (identifier) (def_eq)
+    (conj_list
+      (conj_item (bullet_conj) (nat_number))
+      (conj_item (bullet_conj) (nat_number))
+    )
+  )
+  (module (header_line) (identifier) (header_line) (double_line))
+  (operator_definition (identifier) (def_eq)
+    (conj_list
+      (conj_item (bullet_conj) (nat_number))
+      (conj_item (bullet_conj) (nat_number))
+    )
+  )
+  (variable_declaration (identifier) (identifier))
+(double_line)))
+
+=============|||
+Unicode Conjlist with Empty Tuple
+=============|||
+
+---- MODULE Test ----
+op ≜
+  ∧ 1
+  ∧ ⟨⟩
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (conj_list
+      (conj_item (bullet_conj) (nat_number))
+      (conj_item (bullet_conj) (tuple_literal (langle_bracket) (rangle_bracket)))
+    )
+  )
+(double_line)))
+
+=============|||
+Unicode Conjlist with Empty Set
+=============|||
+
+---- MODULE Test ----
+op ≜
+  ∧ 1
+  ∧ {}
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (conj_list
+      (conj_item (bullet_conj) (nat_number))
+      (conj_item (bullet_conj) (finite_set_literal))
+    )
+  )
+(double_line)))

--- a/test/corpus/disjlist-unicode.txt
+++ b/test/corpus/disjlist-unicode.txt
@@ -1,0 +1,634 @@
+=============|||
+Basic Unicode Disjlist
+=============|||
+
+---- MODULE Test ----
+op ≜
+    ∨ 1
+    ∨ 2
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (disj_list
+      (disj_item (bullet_disj) (nat_number))
+      (disj_item (bullet_disj) (nat_number))
+    )
+  )
+(double_line)))
+
+=============|||
+Inline Unicode Disjlist
+=============|||
+
+---- MODULE Test ----
+op ≜ ∨ 1
+     ∨ 2
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (disj_list
+      (disj_item (bullet_disj) (nat_number))
+      (disj_item (bullet_disj) (nat_number))
+    )
+  )
+(double_line)))
+
+=============|||
+Start-of-Line Unicode Disjlist
+=============|||
+
+---- MODULE Test ----
+op ≜
+∨ 1
+∨ 2
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (disj_list
+      (disj_item (bullet_disj) (nat_number))
+      (disj_item (bullet_disj) (nat_number))
+    )
+  )
+(double_line)))
+
+=============|||
+Left-Shifted Unicode Disjlist
+=============|||
+
+---- MODULE Test ----
+op ≜
+ ∨ 1
+∨ 2
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (bound_infix_op
+      (disj_list (disj_item (bullet_disj) (nat_number)))
+      (lor)
+      (nat_number)
+    )
+  )
+(double_line)))
+
+=============|||
+Right-Shifted Unicode Disjlist
+=============|||
+
+---- MODULE Test ----
+op ≜
+∨ 1
+ ∨ 2
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (disj_list
+      (disj_item
+        (bullet_disj)
+        (bound_infix_op
+          (nat_number)
+          (lor)
+          (nat_number)
+        )
+      )
+    )
+  )
+(double_line)))
+
+=============|||
+Separated Unicode Disjlist
+=============|||
+
+---- MODULE Test ----
+op ≜
+  ∨ 1
+
+  ∨ 2
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (disj_list
+      (disj_item (bullet_disj) (nat_number))
+      (disj_item (bullet_disj) (nat_number))
+    )
+  )
+(double_line)))
+
+=============|||
+Multiline Unicode Disjlist
+=============|||
+
+---- MODULE Test ----
+op ≜
+  ∨ 
+   1
+  ∨
+   2
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (disj_list
+      (disj_item (bullet_disj) (nat_number))
+      (disj_item (bullet_disj) (nat_number))
+    )
+  )
+(double_line)))
+
+=============|||
+Nested Unicode Disjlist
+=============|||
+
+---- MODULE Test ----
+op ≜
+ ∨ ∨ 1
+   ∨ 2
+ ∨ 3
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (disj_list
+      (disj_item
+        (bullet_disj)
+        (disj_list
+          (disj_item (bullet_disj) (nat_number))
+          (disj_item (bullet_disj) (nat_number))
+        )
+      )
+      (disj_item (bullet_disj) (nat_number))
+    )
+  )
+(double_line)))
+
+=============|||
+Start-of-Line Nested Unicode Disjlist
+=============|||
+
+---- MODULE Test ----
+op ≜
+∨ ∨ 1
+  ∨ 2
+∨ 3
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (disj_list
+      (disj_item (bullet_disj)
+        (disj_list
+          (disj_item (bullet_disj) (nat_number))
+          (disj_item (bullet_disj) (nat_number))
+        )
+      )
+      (disj_item (bullet_disj) (nat_number))
+    )
+  )
+(double_line)))
+
+=============|||
+Infix Op Unicode Disjlist
+=============|||
+
+---- MODULE Test ----
+op ≜
+ ∨ 1
+  + 2 
+ ∨ 3
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (disj_list
+      (disj_item
+        (bullet_disj)
+        (bound_infix_op
+          (nat_number)
+          (plus)
+          (nat_number)
+        )
+      )
+      (disj_item (bullet_disj) (nat_number))
+    )
+  )
+(double_line)))
+
+=============|||
+Division Infix Op Unicode Disjlist
+=============|||
+
+---- MODULE Test ----
+op ≜
+ ∨ 1
+  / 2 
+ ∨ 3
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (disj_list
+      (disj_item
+        (bullet_disj)
+        (bound_infix_op
+          (nat_number)
+          (slash)
+          (nat_number)
+        )
+      )
+      (disj_item (bullet_disj) (nat_number))
+    )
+  )
+(double_line)))
+
+=============|||
+Infix Op Terminated Unicode Disjlist
+=============|||
+
+---- MODULE Test ----
+op ≜
+ ∨ 1
+ + 2 
+ ∨ 3
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (bound_infix_op
+      (bound_infix_op
+        (disj_list (disj_item (bullet_disj) (nat_number)))
+        (plus)
+        (nat_number)
+      )
+      (lor)
+      (nat_number)
+    )
+  )
+(double_line)))
+
+=============|||
+Division Infix Op Terminated Unicode Disjlist
+=============|||
+
+---- MODULE Test ----
+op ≜
+ ∨ 1
+ / 2 
+ ∨ 3
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (bound_infix_op
+      (bound_infix_op
+        (disj_list (disj_item (bullet_disj) (nat_number)))
+        (slash)
+        (nat_number)
+      )
+      (lor)
+      (nat_number)
+    )
+  )
+(double_line)))
+
+=============|||
+Not a Unicode Disjlist
+=============|||
+
+---- MODULE Test ----
+op ≜ 1 ∨ 2
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (bound_infix_op
+      (nat_number)
+      (lor)
+      (nat_number)
+    )
+  )
+(double_line)))
+
+=============|||
+Unicode Disjlist with Parentheses
+=============|||
+
+---- MODULE Test ----
+op ≜
+  ∨ (1)
+  ∨ (2)
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (disj_list
+      (disj_item (bullet_disj) (parentheses (nat_number)))
+      (disj_item (bullet_disj) (parentheses (nat_number)))
+    )
+  )
+(double_line)))
+
+=============|||
+Unicode Disjlist Terminated by Parentheses
+=============|||
+
+---- MODULE Test ----
+op ≜ (
+  ∨ 1
+   )
+  ∨ 2
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (bound_infix_op
+      (parentheses
+        (disj_list (disj_item (bullet_disj) (nat_number)))
+      )
+      (lor)
+      (nat_number)
+    )
+  )
+(double_line)))
+
+=============|||
+Nested Unicode Disjlist Terminated by Parentheses
+=============|||
+
+---- MODULE Test ----
+op ≜ (
+  ∨ 1
+  ∨  ∨ 2
+     ∨ 3
+       )
+  ∨ 4
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (bound_infix_op
+      (parentheses
+        (disj_list
+          (disj_item (bullet_disj) (nat_number))
+          (disj_item
+            (bullet_disj)
+            (disj_list
+              (disj_item (bullet_disj) (nat_number))
+              (disj_item (bullet_disj) (nat_number))
+            )
+          )
+        )
+      )
+      (lor)
+      (nat_number)
+    )
+  )
+(double_line)))
+
+=============|||
+Double-Nested Unicode Disjlist Terminated by Parentheses
+=============|||
+
+---- MODULE Test ----
+op ≜
+  ∨ 1
+  ∨  ∨ 2 + (
+        ∨ 3
+        ∨ 4
+          )
+     ∨ 5
+  ∨ 6
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (disj_list
+      (disj_item (bullet_disj) (nat_number))
+      (disj_item
+        (bullet_disj)
+        (disj_list
+          (disj_item
+            (bullet_disj)
+            (bound_infix_op
+              (nat_number)
+              (plus)
+              (parentheses
+                (disj_list
+                  (disj_item (bullet_disj) (nat_number))
+                  (disj_item (bullet_disj) (nat_number))
+                )
+              )
+            )
+          )
+          (disj_item (bullet_disj) (nat_number))
+        )
+      )
+      (disj_item (bullet_disj) (nat_number))
+    )
+  )
+(double_line)))
+
+=============|||
+Overly-Permissive Unicode Disjlist Parentheses Parsing
+=============|||
+
+---- MODULE Test ----
+op ≜
+  ∨ 1
+  ∨ (2 + 3
+)
+  ∨ 4
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (disj_list
+      (disj_item (bullet_disj) (nat_number))
+      (disj_item
+        (bullet_disj)
+        (parentheses
+          (bound_infix_op
+            (nat_number) (plus) (nat_number)
+          )
+        )
+      )
+      (disj_item (bullet_disj) (nat_number))
+    )
+  )
+(double_line)))
+
+=============|||
+Module-End-Terminated Unicode Disjlist
+=============|||
+
+---- MODULE Test ----
+op ≜
+  ∨ 1
+  ∨ 2  ====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (disj_list
+      (disj_item (bullet_disj) (nat_number))
+      (disj_item (bullet_disj) (nat_number))
+    )
+  )
+(double_line)))
+
+=============|||
+Keyword-Unit-Terminated Unicode Disjlist
+=============|||
+
+---- MODULE Test ----
+op1 ≜
+  ∨ 1
+  ∨ 2
+      ASSUME x
+
+op2 ≜
+  ∨ 3
+  ∨ 4
+      LOCAL INSTANCE ModuleName
+
+op3 ≜
+  ∨ 5
+  ∨ 6
+      -----------------
+
+op4 ≜
+  ∨ 7
+  ∨ 8
+      ---- MODULE Nested ----
+      ====
+
+op5 ≜
+  ∨ 9
+  ∨ 10
+      VARIABLES x, y
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (disj_list
+      (disj_item (bullet_disj) (nat_number))
+      (disj_item (bullet_disj) (nat_number))
+    )
+  )
+  (assumption (identifier_ref))
+  (operator_definition (identifier) (def_eq)
+    (disj_list
+      (disj_item (bullet_disj) (nat_number))
+      (disj_item (bullet_disj) (nat_number))
+    )
+  )
+  (local_definition (instance (identifier_ref)))
+  (operator_definition (identifier) (def_eq)
+    (disj_list
+      (disj_item (bullet_disj) (nat_number))
+      (disj_item (bullet_disj) (nat_number))
+    )
+  )
+  (single_line)
+  (operator_definition (identifier) (def_eq)
+    (disj_list
+      (disj_item (bullet_disj) (nat_number))
+      (disj_item (bullet_disj) (nat_number))
+    )
+  )
+  (module (header_line) (identifier) (header_line) (double_line))
+  (operator_definition (identifier) (def_eq)
+    (disj_list
+      (disj_item (bullet_disj) (nat_number))
+      (disj_item (bullet_disj) (nat_number))
+    )
+  )
+  (variable_declaration (identifier) (identifier))
+(double_line)))
+
+=============|||
+Unicode Disjlist with Empty Tuple
+=============|||
+
+---- MODULE Test ----
+op ≜
+  ∨ 1
+  ∨ ⟨⟩
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (disj_list
+      (disj_item (bullet_disj) (nat_number))
+      (disj_item (bullet_disj) (tuple_literal (langle_bracket) (rangle_bracket)))
+    )
+  )
+(double_line)))
+
+=============|||
+Unicode Disjlist with Empty Set
+=============|||
+
+---- MODULE Test ----
+op ≜
+  ∨ 1
+  ∨ {}
+====
+
+-------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (disj_list
+      (disj_item (bullet_disj) (nat_number))
+      (disj_item (bullet_disj) (finite_set_literal))
+    )
+  )
+(double_line)))


### PR DESCRIPTION
Fixes https://github.com/tlaplus-community/tree-sitter-tlaplus/issues/41
Required changes to the tree-sitter library: `get_column` must count codepoints, not bytes