### PR TITLE
Add Emacs `tla-mode` to Notable Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ There are a number of avenues available for consuming & using the parser in a pr
 
 Notable projects currently using or integrating this grammar include:
  * [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) for TLA+ syntax highlighting & code folding in Neovim
+ * [tla-mode](https://github.com/carlthuringer/tla-mode) for TLA+ syntax highlighting in Emacs.
 
 ## Build & Test
 1. Install [Node.js and npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)


### PR DESCRIPTION
I hacked together a -very- basic major mode for Emacs and lifted your syntax highlighting queries. I have to submit a PR to [tree-sitter-langs](https://github.com/emacs-tree-sitter/tree-sitter-langs) also to make it easier to use. Thanks for your effort here!