### PR TITLE
Correctly parse fairness tokens SF_ and WF_

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![crates.io](https://img.shields.io/crates/v/tree-sitter-tlaplus.svg)](https://crates.io/crates/tree-sitter-tlaplus)
 
 ## Overview
-This is a [tree-sitter](https://tree-sitter.github.io/tree-sitter/) grammar for [TLA+](https://en.wikipedia.org/wiki/TLA%2B), the formal specification language.
+This is a [tree-sitter](https://tree-sitter.github.io/tree-sitter/) grammar for the formal specification language [TLA+](https://en.wikipedia.org/wiki/TLA%2B) (and [PlusCal](https://en.wikipedia.org/wiki/PlusCal)).
 Tree-sitter is an incremental error-tolerant parser generator primarily aimed at language tooling such as highlighting, code folding, symbol finding, and other tasks making use of its fully-featured syntax tree query API.
 This grammar is intended to function gracefully while parsing a source file mid-edit, when the syntax isn't fully correct.
 It is also fast enough to re-parse the file on every keystroke.

--- a/grammar.js
+++ b/grammar.js
@@ -1,6 +1,8 @@
 const PREC = {
   COMMENT: 0,
+  IDENTIFIER: 0,
   BLOCK_COMMENT: 1,
+  FAIRNESS: 1,
   PCAL: 2
 }
 
@@ -85,7 +87,6 @@ module.exports = grammar({
 
   externals: $ => [
     $.extramodular_text,
-    $.identifier,
     $._indent,
     $.bullet_conj,
     $.bullet_disj,
@@ -100,8 +101,6 @@ module.exports = grammar({
     $._error_sentinel
   ],
   
-  //word: $ => $.identifier,
-
   supertypes: $ => [
     $._unit,
     $._expr,
@@ -270,16 +269,7 @@ module.exports = grammar({
     // Can contain letters, numbers, and underscores
     // Must contain at least one alphabetic character (not number or _)
     // Cannot start with WF_ or SF_
-    //identifier: $ => /\w*[A-Za-z]\w*/,
-    /*
-    identifier: $ => regexOr(
-      '[SW]',
-      '[SW][^F]\w*',
-      '[SW]F[^_]\w*',
-      '[A-RT-VX-Za-z]\w*',
-      '[^A-Za-z]+[A-Za-z]\w*'
-    ),
-    */
+    identifier: $ => token(prec(PREC.IDENTIFIER, /\w*[A-Za-z]\w*/)),
 
     // EXTENDS Naturals, FiniteSets, Sequences
     extends: $ => seq(
@@ -765,7 +755,7 @@ module.exports = grammar({
 
     // WF_vars(ActionName)
     fairness: $ => seq(
-      choice('WF_', 'SF_'), $._subscript_expr, '(', $._expr, ')'
+      token(prec(PREC.FAIRNESS, choice('WF_', 'SF_')), $._subscript_expr, '(', $._expr, ')'
     ),
 
     // IF a > b THEN a ELSE b

--- a/grammar.js
+++ b/grammar.js
@@ -85,6 +85,7 @@ module.exports = grammar({
 
   externals: $ => [
     $.extramodular_text,
+    $.identifier,
     $._indent,
     $.bullet_conj,
     $.bullet_disj,
@@ -99,7 +100,7 @@ module.exports = grammar({
     $._error_sentinel
   ],
   
-  word: $ => $.identifier,
+  //word: $ => $.identifier,
 
   supertypes: $ => [
     $._unit,
@@ -267,8 +268,18 @@ module.exports = grammar({
     // but tree-sitter currently does not support match exclusion logic.
     // https://github.com/tlaplus-community/tree-sitter-tlaplus/issues/14
     // Can contain letters, numbers, and underscores
-    // If only one character long, must be letter (not number or _)
-    identifier: $ => /\w*[A-Za-z]\w*/,
+    // Must contain at least one alphabetic character (not number or _)
+    // Cannot start with WF_ or SF_
+    //identifier: $ => /\w*[A-Za-z]\w*/,
+    /*
+    identifier: $ => regexOr(
+      '[SW]',
+      '[SW][^F]\w*',
+      '[SW]F[^_]\w*',
+      '[A-RT-VX-Za-z]\w*',
+      '[^A-Za-z]+[A-Za-z]\w*'
+    ),
+    */
 
     // EXTENDS Naturals, FiniteSets, Sequences
     extends: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -1,8 +1,6 @@
 const PREC = {
   COMMENT: 0,
-  IDENTIFIER: 0,
   BLOCK_COMMENT: 1,
-  FAIRNESS: 1,
   PCAL: 2
 }
 
@@ -93,14 +91,18 @@ module.exports = grammar({
     $._dedent,
     $._begin_proof,
     $._begin_proof_step,
-    $.proof_keyword,
-    $.by_keyword,
-    $.obvious_keyword,
-    $.omitted_keyword,
-    $.qed_keyword,
+    'PROOF',
+    'BY',
+    'OBVIOUS',
+    'OMITTED',
+    'QED',
+    'WF_',
+    'SF_',
     $._error_sentinel
   ],
-  
+
+  word: $ => $.identifier,
+
   supertypes: $ => [
     $._unit,
     $._expr,
@@ -269,7 +271,7 @@ module.exports = grammar({
     // Can contain letters, numbers, and underscores
     // Must contain at least one alphabetic character (not number or _)
     // Cannot start with WF_ or SF_
-    identifier: $ => token(prec(PREC.IDENTIFIER, /\w*[A-Za-z]\w*/)),
+    identifier: $ => /[0-9_]*[A-Za-z][A-Za-z0-9_]*/,
 
     // EXTENDS Naturals, FiniteSets, Sequences
     extends: $ => seq(
@@ -755,7 +757,7 @@ module.exports = grammar({
 
     // WF_vars(ActionName)
     fairness: $ => seq(
-      token(prec(PREC.FAIRNESS, choice('WF_', 'SF_')), $._subscript_expr, '(', $._expr, ')'
+      choice('WF_', 'SF_'), $._subscript_expr, '(', $._expr, ')'
     ),
 
     // IF a > b THEN a ELSE b
@@ -1085,16 +1087,16 @@ module.exports = grammar({
 
     // PROOF BY z \in Nat
     terminal_proof: $ => seq(
-      optional(alias($.proof_keyword, 'PROOF')),
+      optional('PROOF'),
       choice(
-        seq(alias($.by_keyword, 'BY'), optional('ONLY'), $.use_body),
-        alias($.obvious_keyword, 'OBVIOUS'),
-        alias($.omitted_keyword, 'OMITTED')
+        seq('BY', optional('ONLY'), $.use_body),
+        'OBVIOUS',
+        'OMITTED'
       )
     ),
 
     non_terminal_proof: $ => seq(
-      optional(alias($.proof_keyword, 'PROOF')),
+      optional('PROOF'),
       $._begin_proof,
       repeat($.proof_step),
       $.qed_step
@@ -1153,7 +1155,7 @@ module.exports = grammar({
     qed_step: $ => seq(
       $._begin_proof_step,
       $.proof_step_id,
-      alias($.qed_keyword, 'QED'),
+      'QED',
       optional($._proof)
     ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1,5 +1,6 @@
 {
   "name": "tlaplus",
+  "word": "identifier",
   "rules": {
     "source_file": {
       "type": "SEQ",
@@ -680,7 +681,7 @@
     },
     "identifier": {
       "type": "PATTERN",
-      "value": "\\w*[A-Za-z]\\w*"
+      "value": "[0-9_]*[A-Za-z][A-Za-z0-9_]*"
     },
     "extends": {
       "type": "SEQ",
@@ -3414,24 +3415,17 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "TOKEN",
-          "content": {
-            "type": "PREC",
-            "value": 1,
-            "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "WF_"
-                },
-                {
-                  "type": "STRING",
-                  "value": "SF_"
-                }
-              ]
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "WF_"
+            },
+            {
+              "type": "STRING",
+              "value": "SF_"
             }
-          }
+          ]
         },
         {
           "type": "SYMBOL",
@@ -6470,12 +6464,7 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "ALIAS",
-              "content": {
-                "type": "SYMBOL",
-                "name": "proof_keyword"
-              },
-              "named": false,
+              "type": "STRING",
               "value": "PROOF"
             },
             {
@@ -6490,12 +6479,7 @@
               "type": "SEQ",
               "members": [
                 {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "by_keyword"
-                  },
-                  "named": false,
+                  "type": "STRING",
                   "value": "BY"
                 },
                 {
@@ -6517,21 +6501,11 @@
               ]
             },
             {
-              "type": "ALIAS",
-              "content": {
-                "type": "SYMBOL",
-                "name": "obvious_keyword"
-              },
-              "named": false,
+              "type": "STRING",
               "value": "OBVIOUS"
             },
             {
-              "type": "ALIAS",
-              "content": {
-                "type": "SYMBOL",
-                "name": "omitted_keyword"
-              },
-              "named": false,
+              "type": "STRING",
               "value": "OMITTED"
             }
           ]
@@ -6545,12 +6519,7 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "ALIAS",
-              "content": {
-                "type": "SYMBOL",
-                "name": "proof_keyword"
-              },
-              "named": false,
+              "type": "STRING",
               "value": "PROOF"
             },
             {
@@ -6893,12 +6862,7 @@
           "name": "proof_step_id"
         },
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "qed_keyword"
-          },
-          "named": false,
+          "type": "STRING",
           "value": "QED"
         },
         {
@@ -9421,24 +9385,32 @@
       "name": "_begin_proof_step"
     },
     {
-      "type": "SYMBOL",
-      "name": "proof_keyword"
+      "type": "STRING",
+      "value": "PROOF"
     },
     {
-      "type": "SYMBOL",
-      "name": "by_keyword"
+      "type": "STRING",
+      "value": "BY"
     },
     {
-      "type": "SYMBOL",
-      "name": "obvious_keyword"
+      "type": "STRING",
+      "value": "OBVIOUS"
     },
     {
-      "type": "SYMBOL",
-      "name": "omitted_keyword"
+      "type": "STRING",
+      "value": "OMITTED"
     },
     {
-      "type": "SYMBOL",
-      "name": "qed_keyword"
+      "type": "STRING",
+      "value": "QED"
+    },
+    {
+      "type": "STRING",
+      "value": "WF_"
+    },
+    {
+      "type": "STRING",
+      "value": "SF_"
     },
     {
       "type": "SYMBOL",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -678,6 +678,10 @@
         }
       ]
     },
+    "identifier": {
+      "type": "PATTERN",
+      "value": "\\w*[A-Za-z]\\w*"
+    },
     "extends": {
       "type": "SEQ",
       "members": [
@@ -3410,17 +3414,24 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "WF_"
-            },
-            {
-              "type": "STRING",
-              "value": "SF_"
+          "type": "TOKEN",
+          "content": {
+            "type": "PREC",
+            "value": 1,
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "WF_"
+                },
+                {
+                  "type": "STRING",
+                  "value": "SF_"
+                }
+              ]
             }
-          ]
+          }
         },
         {
           "type": "SYMBOL",
@@ -9384,10 +9395,6 @@
     {
       "type": "SYMBOL",
       "name": "extramodular_text"
-    },
-    {
-      "type": "SYMBOL",
-      "name": "identifier"
     },
     {
       "type": "SYMBOL",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1,6 +1,5 @@
 {
   "name": "tlaplus",
-  "word": "identifier",
   "rules": {
     "source_file": {
       "type": "SEQ",
@@ -678,10 +677,6 @@
           "value": "ONLY"
         }
       ]
-    },
-    "identifier": {
-      "type": "PATTERN",
-      "value": "\\w*[A-Za-z]\\w*"
     },
     "extends": {
       "type": "SEQ",
@@ -9389,6 +9384,10 @@
     {
       "type": "SYMBOL",
       "name": "extramodular_text"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "identifier"
     },
     {
       "type": "SYMBOL",

--- a/test/corpus/fairness.txt
+++ b/test/corpus/fairness.txt
@@ -1,0 +1,63 @@
+=====================|||
+Basic Weak Fairness
+=====================|||
+
+---- MODULE Test ----
+op == WF_(vars)(x)
+====
+
+---------------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (fairness (parentheses (identifier_ref)) (identifier_ref))
+  )
+(double_line)))
+
+=====================|||
+Basic Strong Fairness
+=====================|||
+
+---- MODULE Test ----
+op == SF_(vars)(x)
+====
+
+---------------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (fairness (parentheses (identifier_ref)) (identifier_ref))
+  )
+(double_line)))
+
+=====================|||
+Weak Fairness Ambiguity
+=====================|||
+
+---- MODULE Test ----
+op == WF_vars(x)
+====
+
+---------------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (fairness (identifier_ref) (identifier_ref))
+  )
+(double_line)))
+
+=====================|||
+Strong Fairness Ambiguity
+=====================|||
+
+---- MODULE Test ----
+op == SF_vars(x)
+====
+
+---------------------|||
+
+(source_file (module (header_line) (identifier) (header_line)
+  (operator_definition (identifier) (def_eq)
+    (fairness (identifier_ref) (identifier_ref))
+  )
+(double_line)))


### PR DESCRIPTION
Fixes #48 
Due to https://github.com/tree-sitter/tree-sitter/issues/1615, this was implemented by moving the `SF_` and `WF_` tokens into the external scanner which is a sort of ultimate lexical precedence override.