### PR TITLE
Exposed bullet_conj and bullet_disj to literal queries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-tlaplus"
 description = "A tree-sitter grammar for TLA+ and PlusCal"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Andrew Helwer", "Vasiliy Morkovkin"]
 license = "MIT"
 readme = "README.md"

--- a/grammar.js
+++ b/grammar.js
@@ -77,8 +77,7 @@ module.exports = grammar({
     $.leading_extramodular_text,
     $.trailing_extramodular_text,
     $._indent,
-    $.bullet_conj,
-    $.bullet_disj,
+    $._bullet,
     $._dedent,
     $._begin_proof,
     $._begin_proof_step,
@@ -813,7 +812,9 @@ module.exports = grammar({
     ),
 
     // /\ x
-    conj_item: $ => seq($.bullet_conj, $._expr),
+    conj_item: $ => seq($._bullet, $.bullet_conj, $._expr),
+
+    bullet_conj: $ => choice('/\\', '∧'),
 
     // This makes use of the external scanner.
     // \/ x
@@ -825,7 +826,9 @@ module.exports = grammar({
     ),
 
     // \/ x
-    disj_item: $ => seq($.bullet_disj, $._expr),
+    disj_item: $ => seq($._bullet, $.bullet_disj, $._expr),
+
+    bullet_disj: $ => choice('\\/', '∨'),
 
     /************************************************************************/
     /* PREFIX, INFIX, AND POSTFIX OPERATOR DEFINITIONS                      */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tlaplus/tree-sitter-tlaplus",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "A tree-sitter grammar for TLA+ and PlusCal",
   "main": "bindings/node",
   "scripts": {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3723,11 +3723,28 @@
       "members": [
         {
           "type": "SYMBOL",
+          "name": "_bullet"
+        },
+        {
+          "type": "SYMBOL",
           "name": "bullet_conj"
         },
         {
           "type": "SYMBOL",
           "name": "_expr"
+        }
+      ]
+    },
+    "bullet_conj": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "/\\"
+        },
+        {
+          "type": "STRING",
+          "value": "∧"
         }
       ]
     },
@@ -3756,11 +3773,28 @@
       "members": [
         {
           "type": "SYMBOL",
+          "name": "_bullet"
+        },
+        {
+          "type": "SYMBOL",
           "name": "bullet_disj"
         },
         {
           "type": "SYMBOL",
           "name": "_expr"
+        }
+      ]
+    },
+    "bullet_disj": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\/"
+        },
+        {
+          "type": "STRING",
+          "value": "∨"
         }
       ]
     },
@@ -9474,11 +9508,7 @@
     },
     {
       "type": "SYMBOL",
-      "name": "bullet_conj"
-    },
-    {
-      "type": "SYMBOL",
-      "name": "bullet_disj"
+      "name": "_bullet"
     },
     {
       "type": "SYMBOL",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1049,6 +1049,16 @@
     "fields": {}
   },
   {
+    "type": "bullet_conj",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "bullet_disj",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "cap",
     "named": true,
     "fields": {}
@@ -5449,14 +5459,6 @@
   },
   {
     "type": "boolean_set",
-    "named": true
-  },
-  {
-    "type": "bullet_conj",
-    "named": true
-  },
-  {
-    "type": "bullet_disj",
     "named": true
   },
   {

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -53,8 +53,7 @@ namespace {
     LEADING_EXTRAMODULAR_TEXT,  // Freeform text at the start of the file.
     TRAILING_EXTRAMODULAR_TEXT, // Freeform text between or after modules.
     INDENT,             // Marks beginning of junction list.
-    BULLET_CONJ,        // New item of a conjunction list.
-    BULLET_DISJ,        // New item of a disjunction list.
+    BULLET,             // New item of a junction list.
     DEDENT,             // Marks end of junction list.
     BEGIN_PROOF,        // Marks the beginning of an entire proof.
     BEGIN_PROOF_STEP,   // Marks the beginning of a proof step.
@@ -1066,26 +1065,15 @@ namespace {
     }
 
     /**
-     * Emits a BULLET_CONJ or BULLET_DISJ token, marking the start of a
-     * new item in the current jlist.
+     * Emits a BULLET token, marking the start of a new item in the current
+     * jlist.
      *
      * @param lexer The tree-sitter lexing control structure.
-     * @param type The type of junction token to emit.
+     * @param type The type of junction list.
      * @return Whether a BULLET token was emitted.
      */
     bool emit_bullet(TSLexer* const lexer, const JunctType type) {
-      switch (type) {
-        case JunctType_CONJUNCTION:
-          lexer->result_symbol = BULLET_CONJ;
-          break;
-        case JunctType_DISJUNCTION:
-          lexer->result_symbol = BULLET_DISJ;
-          break;
-        default:
-          return false;
-      }
-      
-      lexer->mark_end(lexer);
+      lexer->result_symbol = BULLET;
       return true;
     }
 


### PR DESCRIPTION
Currently, the `$.bullet_conj` and `$.bullet_disj` tokens are resolved in the external scanner. This means you can't write a query like `(bullet_conj "/\\")` or `(bullet_disj "\\/")` to specifically search for ASCII examples of those symbols instead of their unicode counterparts. These changes move the parsing of `$.bullet_conj` and `$.bullet_disj` back into the grammar itself. This saves a few megabytes of generated parser code, at the cost of reading the tokens twice - once while looking ahead in the external scanner (which now emits the invisible `$._bullet` token), then again in the regular grammar lexer. These changes will be helpful with the [tlaplus-unicode-converter](https://github.com/tlaplus-community/tlaplus-unicode-converter).