### PR TITLE
Change unit test instruction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,11 @@ jobs:
       - name: Build
         run: npm install
       - name: Unit Tests
-        run: node_modules/.bin/tree-sitter test
+        run: npx tree-sitter test
       - name: Corpus Tests
         shell: pwsh
         run: |
-          node_modules/.bin/tree-sitter init-config
+          npx tree-sitter init-config
           $specs = Get-ChildItem `
             -Path .\test\examples\external\specifications `
             -Filter "*.tla" `
@@ -36,7 +36,7 @@ jobs:
           Push-Location .\test\examples\external\specifications
           $specs | Resolve-Path -Relative
           Pop-Location
-          $failures = $specs.FullName |% {node_modules/.bin/tree-sitter parse -q $_}
+          $failures = $specs.FullName |% {npx tree-sitter parse -q $_}
           $failures
           exit $failures.length
       - name: Query File Tests
@@ -49,13 +49,13 @@ jobs:
           $results = $query_files.FullName `
             |% { `
               Write-Host (Resolve-Path -Path $_ -Relative); `
-              node_modules/.bin/tree-sitter query $_ ./test/examples/Highlight.tla | Out-Null; `
+              npx tree-sitter query $_ ./test/examples/Highlight.tla | Out-Null; `
               $lastexitcode `
             }
           $failures = $results |? {$_ -ne 0}
           exit $failures.length
       - name: Generate parser code
-        run: node_modules/.bin/tree-sitter generate
+        run: npx tree-sitter generate
       - name: Renormalize line endings
         shell: bash
         run: git add --renormalize .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           version: 2.0.16
       - name: Generate parser WASM
-        run: node_modules/.bin/tree-sitter build-wasm
+        run: npx tree-sitter build-wasm
       - name: Publish
         run: npm publish --access public
         env:

--- a/README.md
+++ b/README.md
@@ -50,8 +50,7 @@ As applicable, query files for integrations live in the `integrations` directory
 1. Install a C compiler
 1. Clone the repo with the `--recurse-submodules` parameter
 1. Open a terminal in the repo root and run `npm install` to download packages & build the project
-1. Ensure `node_modules/.bin` is on your path
-1. Run `tree-sitter test` to run the unit tests
+1. Run `npx tree-sitter test` to run the unit tests
 1. Run corpus tests (parsing all specifications in the [tlaplus/examples](https://github.com/tlaplus/examples) repo) with the following powershell commands (no output if successful):
    - `$specs = Get-ChildItem -Path .\test\examples\external\specifications -Filter "*.tla" -Exclude "Reals.tla","Naturals.tla" -Recurse`
    - `$specs |% {tree-sitter parse -q $_}`

--- a/README.md
+++ b/README.md
@@ -50,17 +50,17 @@ As applicable, query files for integrations live in the `integrations` directory
 1. Install a C compiler
 1. Clone the repo with the `--recurse-submodules` parameter
 1. Open a terminal in the repo root and run `npm install` to download packages & build the project
-1. Run `npx tree-sitter test` to run the unit tests
+1. Run `npm test` to run the unit tests
 1. Run corpus tests (parsing all specifications in the [tlaplus/examples](https://github.com/tlaplus/examples) repo) with the following powershell commands (no output if successful):
    - `$specs = Get-ChildItem -Path .\test\examples\external\specifications -Filter "*.tla" -Exclude "Reals.tla","Naturals.tla" -Recurse`
-   - `$specs |% {tree-sitter parse -q $_}`
+   - `$specs |% {npx tree-sitter parse -q $_}`
 
 ## The Playground
 The playground enables you to easily try out the parser in your browser.
 You can use the playground [online](https://tlaplus-community.github.io/tree-sitter-tlaplus/) (serving the latest release) or set it up locally as follows:
-1. Install Emscripten 2.0.17 or **earlier** ([why?](https://github.com/tree-sitter/tree-sitter/issues/1098#issuecomment-842326203))
-1. Run `tree-sitter build-wasm`
-1. Run `tree-sitter playground`
+1. Install Emscripten 2.0.17 or **earlier** ([why?](https://github.com/tree-sitter/tree-sitter/issues/1098#issuecomment-842326203));
+1. Run `npx tree-sitter build-wasm`;
+1. Run `npx tree-sitter playground`;
 
 The playground consists of a pane containing an editable TLA+ spec, and another pane containing the parse tree for that spec.
 The parse tree is updated in real time as you edit the TLA+ spec.
@@ -72,6 +72,6 @@ You can also click the "query" checkbox to open a third pane for testing [tree q
 ```
 
 ## Contributions
-Pull requests are welcome. If you modify `grammar.js`, make sure you run `tree-sitter generate` before committing & pushing.
+Pull requests are welcome. If you modify `grammar.js`, make sure you run `npx tree-sitter generate` before committing & pushing.
 Generated files are (unfortunately) currently present in the repo but will hopefully be removed in [the future](https://github.com/tree-sitter/tree-sitter/discussions/1243).
 Their correspondence is enforced during CI.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A tree-sitter grammar for TLA+ and PlusCal",
   "main": "bindings/node",
   "scripts": {
-    "test": "tree-sitter test"
+    "test": "npx tree-sitter test"
   },
   "repository": {
     "type": "git",
@@ -18,7 +18,9 @@
     "parser"
   ],
   "author": "Andrew Helwer",
-  "contributors": ["Vasiliy Morkovkin"],
+  "contributors": [
+    "Vasiliy Morkovkin"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/tlaplus-community/tree-sitter-tlaplus/issues"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A tree-sitter grammar for TLA+ and PlusCal",
   "main": "bindings/node",
   "scripts": {
-    "test": "npx tree-sitter test"
+    "test": "tree-sitter test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
No need for `node_modules/bin` to be in PATH. Since `npx` comes with `npm`, we can use `npx tree-sitter test`.