### PR TITLE
Add corpus test scripts + update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,13 @@ As applicable, query files for integrations live in the `integrations` directory
 1. Install a C compiler
 1. Clone the repo with the `--recurse-submodules` parameter
 1. Open a terminal in the repo root and run `npm install` to download packages & build the project
-1. Run `npm test` to run the unit tests
-1. Run corpus tests (parsing all specifications in the [tlaplus/examples](https://github.com/tlaplus/examples) repo) with the following powershell commands (no output if successful):
-   - `$specs = Get-ChildItem -Path .\test\examples\external\specifications -Filter "*.tla" -Exclude "Reals.tla","Naturals.tla" -Recurse`
-   - `$specs |% {npx tree-sitter parse -q $_}`
+1. Run `npm test` to run Tree-sitter unit tests
+1. Before running corpus tests (which parse all specifications in the [tlaplus/examples](https://github.com/tlaplus/examples) repo), you might have to run `npx tree-sitter init-config`. Then, run either:
+
+   - `./test/run-corpus.sh` (Shell script on Unix operating systems)
+   - `.\test\run-corpus.ps1` (Powershell script on Windows)
+
+   No output means successful tests.
 
 ## The Playground
 The playground enables you to easily try out the parser in your browser.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A tree-sitter grammar for TLA+ and PlusCal",
   "main": "bindings/node",
   "scripts": {
-    "test": "tree-sitter test"
+    "test": "npx tree-sitter test"
   },
   "repository": {
     "type": "git",

--- a/test/run-corpus.ps1
+++ b/test/run-corpus.ps1
@@ -1,0 +1,2 @@
+$specs = Get-ChildItem -Path .\test\examples\external\specifications -Filter "*.tla" -Exclude "Reals.tla","Naturals.tla" -Recurse
+$specs |% {npx tree-sitter parse -q $_}

--- a/test/run-corpus.sh
+++ b/test/run-corpus.sh
@@ -1,0 +1,4 @@
+#! /bin/sh
+
+find "test/examples/external/specifications" -name "*.tla" ! -iname "Reals.tla" ! -iname "Naturals.tla" |
+    xargs -P $(nproc) -I {} "npx tree-sitter parse -q {}"


### PR DESCRIPTION
Closes #70 

Now people can run corpus tests in parallel on Unix OSs, but the CI tests are still powershell/sequential.