### PR TITLE
Fixes crash when encountering QED keyword during error recovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
         run: npm install
       - name: Unit Tests
         run: ./node_modules/.bin/tree-sitter test
+      - name: Crash Regression Tests
+        run: ./node_modules/.bin/tree-sitter parse test/crash_regressions/QEDErrorRecovery.tla
       - name: Corpus Tests (Windows)
         if: matrix.os == 'windows-latest'
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,10 @@ jobs:
       - name: Unit Tests
         run: ./node_modules/.bin/tree-sitter test
       - name: Crash Regression Tests
+        shell: bash
         run: |
           ./node_modules/.bin/tree-sitter init-config
-          ./node_modules/.bin/tree-sitter parse test/crash_regressions/QEDErrorRecovery.tla
+          ./node_modules/.bin/tree-sitter parse test/crash_regressions/QEDErrorRecovery.tla || (($? == 1))
       - name: Corpus Tests (Windows)
         if: matrix.os == 'windows-latest'
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,13 @@ jobs:
         shell: pwsh
         run: .\test\run-corpus.ps1
       - name: Corpus Tests (Unix)
-        if: matrix.os != 'windows-latest'
+        if: matrix.os == 'ubuntu-latest'
         shell: bash
-        run: |
-          ./test/run-corpus.sh
+        run: ./test/run-corpus.sh --parallel
+      - name: Corpus Tests (MacOS)
+        if: matrix.os == 'macos-latest'
+        shell: bash
+        run: ./test/run-corpus.sh
       - name: Query File Tests
         shell: pwsh
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,18 +25,17 @@ jobs:
       - name: Unit Tests
         run: ./node_modules/.bin/tree-sitter test
       - name: Crash Regression Tests
-        run: ./node_modules/.bin/tree-sitter parse test/crash_regressions/QEDErrorRecovery.tla
+        run: |
+          ./node_modules/.bin/tree-sitter init-config
+          ./node_modules/.bin/tree-sitter parse test/crash_regressions/QEDErrorRecovery.tla
       - name: Corpus Tests (Windows)
         if: matrix.os == 'windows-latest'
         shell: pwsh
-        run: |
-          .\node_modules\.bin\tree-sitter init-config
-          .\test\run-corpus.ps1
+        run: .\test\run-corpus.ps1
       - name: Corpus Tests (Unix)
         if: matrix.os != 'windows-latest'
         shell: bash
         run: |
-          ./node_modules/.bin/tree-sitter init-config
           ./test/run-corpus.sh
       - name: Query File Tests
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         shell: bash
         run: |
           ./node_modules/.bin/tree-sitter init-config
-          ./node_modules/.bin/tree-sitter parse test/crash_regressions/QEDErrorRecovery.tla || (($? == 1))
+          ./node_modules/.bin/tree-sitter parse -q test/crash_regressions/QEDErrorRecovery.tla || (($? == 1))
       - name: Corpus Tests (Windows)
         if: matrix.os == 'windows-latest'
         shell: pwsh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-tlaplus"
 description = "A tree-sitter grammar for TLA⁺ and PlusCal"
-version = "1.0.2"
+version = "1.0.3"
 authors = ["Andrew Helwer", "Vasiliy Morkovkin"]
 license = "MIT"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The most important files in this repo are `grammar.js` and `src/scanner.cc`.
 The former is the source of truth for parser code generation and the latter contains logic for parsing the context-sensitive parts of TLA⁺ like nested proofs and conjunction/disjunction lists.
 
 A blog post detailing the development process of this parser can be found [here](https://ahelwer.ca/post/2023-01-11-tree-sitter-tlaplus/).
+This repo is [mirrored on sourcehut](mirrored at https://git.sr.ht/~ahelwer/tree-sitter-tlaplus).
 
 ## Aims & Capabilities
 The aim of this project is to facilitate creation of modern user-assistive language tooling for TLA⁺.
@@ -78,7 +79,10 @@ You can also click the "query" checkbox to open a third pane for testing [tree q
 ```
 
 ## Contributions
+One easy way to contribute is to add your TLA⁺ specifications to the [tlaplus/examples](https://github.com/tlaplus/examples) repo, which this grammar uses as a valuable test corpus!
+
 Pull requests are welcome. If you modify `grammar.js`, make sure you run `npx tree-sitter generate` before committing & pushing.
 Generated files are (unfortunately) currently present in the repo but will hopefully be removed in [the future](https://github.com/tree-sitter/tree-sitter/discussions/1243).
 Their correspondence is enforced during CI.
+
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tlaplus/tree-sitter-tlaplus",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A tree-sitter grammar for TLA⁺ and PlusCal",
   "main": "bindings/node",
   "scripts": {

--- a/test/crash_regressions/QEDErrorRecovery.tla
+++ b/test/crash_regressions/QEDErrorRecovery.tla
@@ -1,0 +1,7 @@
+---- MODULE Test ----
+op == [ ]
+THEOREM TRUE
+<*> A
+<*> QED
+====
+

--- a/test/run-corpus.sh
+++ b/test/run-corpus.sh
@@ -1,7 +1,8 @@
 #! /bin/sh
 
 specs=$(find "test/examples" -name "*.tla")
-ncpu=$(command -v nproc > /dev/null && nproc || echo 1)
+ncpu=$(($# > 0 ? $(command -v nproc > /dev/null && nproc || echo 1) : 1))
+echo "Concurrent parser count: $ncpu"
 failures=$(echo "$specs" | xargs -P $ncpu -I {} ./node_modules/.bin/tree-sitter parse -q {})
 if test -z "$failures"; then
   exit 0


### PR DESCRIPTION
Fixes #60
Turns out calling `std::vector<T>.pop_back()` on an empty vector is undefined behavior. In this case, it manifested as the vector size being set to `-1` and thus set to the largest possible value `size_t`, so later attempts to serialize that vector of the entire memory of the computer did not succeed. Yet another reason to love C++! I can't wait for the world to be rid of this stupid language.