### PR TITLE
Hardened scanner against further segfaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
         run: |
           ./node_modules/.bin/tree-sitter init-config
           ./node_modules/.bin/tree-sitter parse -q test/crash_regressions/QEDErrorRecovery.tla || (($? == 1))
+          ./node_modules/.bin/tree-sitter parse -q test/crash_regressions/QEDErrorRecovery2.tla || (($? == 1))
       - name: Corpus Tests (Windows)
         if: matrix.os == 'windows-latest'
         shell: pwsh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-tlaplus"
 description = "A tree-sitter grammar for TLA⁺ and PlusCal"
-version = "1.0.3"
+version = "1.0.4"
 authors = ["Andrew Helwer", "Vasiliy Morkovkin"]
 license = "MIT"
 readme = "README.md"

--- a/grammar.js
+++ b/grammar.js
@@ -245,7 +245,7 @@ module.exports = grammar({
     label_as:           $ => choice('::', '∷'),
     placeholder:        $ => '_',
     bullet_conj:        $ => choice('/\\', '∧'),
-    bullet_disj: $ => choice('\\/', '∨'),
+    bullet_disj:        $ => choice('\\/', '∨'),
 
     // The set of all reserved keywords
     keyword: $ => choice(
@@ -1166,10 +1166,7 @@ module.exports = grammar({
     ),
 
     use_or_hide: $ => seq(
-      choice(
-        seq('USE', optional('ONLY')),
-        'HIDE'
-      ),
+      choice('USE', 'HIDE'),
       $.use_body
     ),
 

--- a/integrations/nvim/queries/tlaplus/highlights.scm
+++ b/integrations/nvim/queries/tlaplus/highlights.scm
@@ -81,7 +81,6 @@
   (pcal_algorithm_start)
   "algorithm"
   "assert"
-  "await"
   "begin"
   "call"
   "define"
@@ -98,6 +97,9 @@
   "when"
   "with"
 ] @keyword
+[
+  "await"
+] @keyword.coroutine
 (pcal_with ("=") @keyword)
 (pcal_process ("=") @keyword)
 [ 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tlaplus/tree-sitter-tlaplus",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A tree-sitter grammar for TLA⁺ and PlusCal",
   "main": "bindings/node",
   "scripts": {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -7035,25 +7035,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "USE"
-                },
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "ONLY"
-                    },
-                    {
-                      "type": "BLANK"
-                    }
-                  ]
-                }
-              ]
+              "type": "STRING",
+              "value": "USE"
             },
             {
               "type": "STRING",

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -1252,6 +1252,7 @@ namespace {
     ) {
       return is_in_jlist()
         && valid_symbols[DEDENT]
+        && !this->jlists.empty()
         && emit_dedent(lexer);
     }
 
@@ -1535,7 +1536,7 @@ namespace {
       TSLexer* const lexer,
       const bool* const valid_symbols
     ) {
-      if (valid_symbols[QED_KEYWORD]) {
+      if (is_in_proof()) {
         last_proof_level = get_current_proof_level();
         proofs.pop_back();
       }
@@ -1749,7 +1750,7 @@ namespace {
         this->current_context.deserialize(NULL, 0);
         lexer->result_symbol = PCAL_START;
         return true;
-      } else if (valid_symbols[PCAL_END]) {
+      } else if (valid_symbols[PCAL_END] && !this->enclosing_contexts.empty()) {
         // Exiting PlusCal block; rehydrate context then pop
         std::vector<char>& next = this->enclosing_contexts.back();
         this->current_context.deserialize(next.data(), next.size());

--- a/test/corpus/proofs.txt
+++ b/test/corpus/proofs.txt
@@ -135,7 +135,7 @@ THEOREM TRUE
 <1>h..... CASE 6
 <1>i..... PICK a, b, c : 7
 <1>j..... HIDE 8
-<1>k..... USE ONLY 9
+<1>k..... USE 9
 <1>l..... INSTANCE M
 <1>m..... QED
 ====

--- a/test/crash_regressions/QEDErrorRecovery2.tla
+++ b/test/crash_regressions/QEDErrorRecovery2.tla
@@ -1,0 +1,5 @@
+---- MODULE Test ----
+THEOREM A
+  <1> QED BY B
+  <1> QED
+=====================

--- a/test/sanitize/runner.cc
+++ b/test/sanitize/runner.cc
@@ -17,6 +17,8 @@ int main(int const argc, char const* const argv[]) {
   }
 
   TSParser *parser = ts_parser_new();
+  TSLogger *logger = ts_parser_logger(parser);
+  logger->log = true;
   bool language_ok = ts_parser_set_language(parser, TS_LANG());
   assert(language_ok);
 

--- a/test/sanitize/runner.cc
+++ b/test/sanitize/runner.cc
@@ -17,8 +17,6 @@ int main(int const argc, char const* const argv[]) {
   }
 
   TSParser *parser = ts_parser_new();
-  TSLogger *logger = ts_parser_logger(parser);
-  logger->log = true;
   bool language_ok = ts_parser_set_language(parser, TS_LANG());
   assert(language_ok);
 


### PR DESCRIPTION
It is not sufficient to rely on the valid symbols array passed by the scanner; instead, check whether jlist/proof/pcal block stacks are empty before popping them. Fixes another bug similar to #60 

Fixes #80 while we're making changes. Also updated the nvim-treesitter query files to reflect a new coroutine query that was added.