### PR TITLE
Set proper lexical precedence for string contents

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-tlaplus"
 description = "A tree-sitter grammar for TLA⁺ and PlusCal"
-version = "1.0.7"
+version = "1.0.8"
 authors = ["Andrew Helwer", "Vasiliy Morkovkin"]
 license = "MIT"
 readme = "README.md"

--- a/grammar.js
+++ b/grammar.js
@@ -1,7 +1,8 @@
 const PREC = {
   COMMENT: 0,
   BLOCK_COMMENT: 1,
-  PCAL: 2
+  PCAL: 2,
+  STRING: 3
 }
 
 // A sequence of one or more comma-separated strings matching the rule
@@ -585,17 +586,16 @@ module.exports = grammar({
     string: $ => seq(
       '"',
       repeat(choice(
-        token.immediate(/[^"\n]/),
+        // Proper lexical precedence allows to parse strings like "(*",
+        // winning over block comment lexemes
+        token.immediate(prec(PREC.STRING, /[^"\n]/)),
         $.escape_char
       )),
       token.immediate('"')
     ),
 
     // "/\\", "say \"hello\" back", "one\ntwo"
-    escape_char: $ => seq(
-      token.immediate('\\'),
-      token.immediate(/./)
-    ),
+    escape_char: $ => token.immediate(prec(PREC.STRING, seq('\\', /./))),
 
     // TRUE, FALSE, BOOLEAN
     boolean: $ => choice('TRUE', 'FALSE'),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tlaplus/tree-sitter-tlaplus",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "A tree-sitter grammar for TLA⁺ and PlusCal",
   "main": "bindings/node",
   "scripts": {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2425,8 +2425,12 @@
               {
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
-                  "type": "PATTERN",
-                  "value": "[^\"\\n]"
+                  "type": "PREC",
+                  "value": 3,
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\"\\n]"
+                  }
                 }
               },
               {
@@ -2446,23 +2450,24 @@
       ]
     },
     "escape_char": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "IMMEDIATE_TOKEN",
-          "content": {
-            "type": "STRING",
-            "value": "\\"
-          }
-        },
-        {
-          "type": "IMMEDIATE_TOKEN",
-          "content": {
-            "type": "PATTERN",
-            "value": "."
-          }
+      "type": "IMMEDIATE_TOKEN",
+      "content": {
+        "type": "PREC",
+        "value": 3,
+        "content": {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "\\"
+            },
+            {
+              "type": "PATTERN",
+              "value": "."
+            }
+          ]
         }
-      ]
+      }
     },
     "boolean": {
       "type": "CHOICE",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1352,11 +1352,6 @@
     "fields": {}
   },
   {
-    "type": "escape_char",
-    "named": true,
-    "fields": {}
-  },
-  {
     "type": "eventually",
     "named": true,
     "fields": {}
@@ -5224,10 +5219,6 @@
     "named": false
   },
   {
-    "type": "\\",
-    "named": false
-  },
-  {
     "type": "\\/",
     "named": false
   },
@@ -5550,6 +5541,10 @@
   {
     "type": "end",
     "named": false
+  },
+  {
+    "type": "escape_char",
+    "named": true
   },
   {
     "type": "extramodular_text",

--- a/test/corpus/string.txt
+++ b/test/corpus/string.txt
@@ -66,3 +66,29 @@ op == <<"/\\", "\\/">>
   )
 (double_line)))
 
+==================|||
+String with comment start
+==================|||
+
+---- MODULE Test ----
+op1 == "\*"
+op2 == "(*"
+====
+
+------------------|||
+
+(source_file
+  (module
+    (header_line)
+    (identifier)
+    (header_line)
+    (operator_definition
+      (identifier)
+      (def_eq)
+      (string
+        (escape_char)))
+    (operator_definition
+      (identifier)
+      (def_eq)
+      (string))
+    (double_line)))


### PR DESCRIPTION
Fixes #83

Problem
----
The grammar fails to parse strings with comment start lexemes inside them: `"\*"` and `"(*"`

Solution
----
Specify a higher lexical precedence for string contents than for comments