### PR TITLE
.wasm file missing in 1.2.x npm.js package

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "prebuilds/**",
     "bindings/node/*",
     "queries/*",
-    "src/**"
+    "src/**",
+    "*.wasm"
   ],
   "tree-sitter": [
     {


### PR DESCRIPTION
https://github.com/tlaplus-community/tree-sitter-tlaplus/issues/104