### PR TITLE
Binary incompatibilities because of emscripten 2.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,3 +80,17 @@ jobs:
         run: |
           diff_count=$(git status --porcelain=v1 2>/dev/null | wc -l)
           exit $diff_count
+      - name: Install Emscripten
+        uses: mymindstorm/setup-emsdk@v14
+        with:
+          version: 2.0.16
+      - name: Generate parser WASM
+        run: npx tree-sitter build-wasm
+      - name: Publish
+        run: npm pack
+      - name: Upload npm tarball.
+        uses: actions/upload-artifact@v4
+        with:
+          name: tlaplus-tree-sitter-tlaplus-${{matrix.os}}.tgz
+          path: '*.tgz'
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Install Emscripten
         uses: mymindstorm/setup-emsdk@v14
         with:
-          version: 2.0.16
+          version: 3.1.6
       - name: Generate parser WASM
         run: npx tree-sitter build-wasm
       - name: Publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Emscripten
         uses: mymindstorm/setup-emsdk@v14
         with:
-          version: 2.0.16
+          version: 3.1.6
       - name: Generate parser WASM
         run: npx tree-sitter build-wasm
       - name: Publish


### PR DESCRIPTION
If the .wasm has been generated with emscripten 2.x, it is incompatible with recent dependencies in the ecosystem: `null function or function signature mismatch` (when loading).

Related: https://github.com/microsoft/genaiscript/issues/314