### PR TITLE
Call canary workflow from release

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -25,9 +25,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.12
-      - name: Install setuptools for Windows build
-        if: matrix.os == 'windows-latest'
-        run: python -m pip install --upgrade setuptools
 
       # Input release version into package files
       - name: Modify package files (Linux & macOS)
@@ -62,7 +59,6 @@ jobs:
 
       # Test consumers using actual published packages
       - name: Test rust consumer
-        if: matrix.os != 'windows-latest'
         working-directory: test/consumers/rust
         run: cargo run
       - name: Test node.js consumer

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,15 +148,17 @@ jobs:
         run: cargo publish --token ${{secrets.CRATES_AUTH_TOKEN}}
 
       # Downstream Consumers
-      - name: Trigger canary workflow
-        uses: benc-uk/workflow-dispatch@v1
-        with:
-          workflow: canary.yml
-          inputs: '{ "version": "${{ github.ref_name }}" }'
       - name: Trigger playground update
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.GH_PAT }}
           repository: tlaplus-community/tlaplus-community.github.io
           event-type: tree-sitter-tlaplus-release
+
+  trigger-canary:
+    name: Trigger canary workflow
+    needs: [publish-packages]
+    uses: tlaplus-community/tree-sitter-tlaplus/.github/workflows/canary.yml
+    with:
+      version: ${{ github.ref_name }}
 


### PR DESCRIPTION
Also remove step that installs setuptools on windows; no longer necessary since NPM & Python packages are distributed with prebuilt artifacts.