### PR TITLE
Correctly parse junct token as higher-level op parameter

### DIFF
--- a/test/corpus/infix_op.txt
+++ b/test/corpus/infix_op.txt
@@ -703,6 +703,7 @@ op == f(
   <=>,
   =>,
   \in,
+  /\,
   \land,
   =|,
   ~>,
@@ -710,6 +711,7 @@ op == f(
   =<,
   \leq,
   \ll,
+  \/,
   \lor,
   -|,
   <,
@@ -809,12 +811,14 @@ op == f(
     parameter: (infix_op_symbol (implies))
     parameter: (infix_op_symbol (in))
     parameter: (infix_op_symbol (land))
+    parameter: (infix_op_symbol (land))
     parameter: (infix_op_symbol (ld_ttile))
     parameter: (infix_op_symbol (leads_to))
     parameter: (infix_op_symbol (leq))
     parameter: (infix_op_symbol (leq))
     parameter: (infix_op_symbol (leq))
     parameter: (infix_op_symbol (ll))
+    parameter: (infix_op_symbol (lor))
     parameter: (infix_op_symbol (lor))
     parameter: (infix_op_symbol (ls_ttile))
     parameter: (infix_op_symbol (lt))

--- a/test/corpus/regression.txt
+++ b/test/corpus/regression.txt
@@ -33,3 +33,47 @@ op ==
   )
 (double_line)))
 
+=============|||
+Junct Tokens as Higher-Level Parameters (TSTLA#GH96)
+=============|||
+
+---- MODULE Test ----
+op == op(/\, x, /\)
+op == op(∧, x, ∧)
+op == op(\/, x, \/)
+op == op(∨, x, ∨)
+====
+
+--------------|||
+
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (identifier) (def_eq) definition:
+    (bound_op name: (identifier_ref)
+      parameter: (infix_op_symbol (land))
+      parameter: (identifier_ref)
+      parameter: (infix_op_symbol (land))
+    )
+  )
+  (operator_definition name: (identifier) (def_eq) definition:
+    (bound_op name: (identifier_ref)
+      parameter: (infix_op_symbol (land))
+      parameter: (identifier_ref)
+      parameter: (infix_op_symbol (land))
+    )
+  )
+  (operator_definition name: (identifier) (def_eq) definition:
+    (bound_op name: (identifier_ref)
+      parameter: (infix_op_symbol (lor))
+      parameter: (identifier_ref)
+      parameter: (infix_op_symbol (lor))
+    )
+  )
+  (operator_definition name: (identifier) (def_eq) definition:
+    (bound_op name: (identifier_ref)
+      parameter: (infix_op_symbol (lor))
+      parameter: (identifier_ref)
+      parameter: (infix_op_symbol (lor))
+    )
+  )
+(double_line)))
+

--- a/test/corpus/unicode/operators-unicode.txt
+++ b/test/corpus/unicode/operators-unicode.txt
@@ -471,10 +471,12 @@ op ≜ f(
   ⇔,
   ⇒,
   ∈,
+  ∧,
   ⫤,
   ↝,
   ≤,
   ≪,
+  ∨,
   ⊣,
   ≠,
   ∉,
@@ -542,10 +544,12 @@ op ≜ f(
     parameter: (infix_op_symbol (iff))
     parameter: (infix_op_symbol (implies))
     parameter: (infix_op_symbol (in))
+    parameter: (infix_op_symbol (land))
     parameter: (infix_op_symbol (ld_ttile))
     parameter: (infix_op_symbol (leads_to))
     parameter: (infix_op_symbol (leq))
     parameter: (infix_op_symbol (ll))
+    parameter: (infix_op_symbol (lor))
     parameter: (infix_op_symbol (ls_ttile))
     parameter: (infix_op_symbol (neq))
     parameter: (infix_op_symbol (notin))


### PR DESCRIPTION
Closes #96