### PR TITLE
Identify number sets in operator definitions and subexpression references

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -103,7 +103,8 @@ module.exports = grammar({
     $._op,
     $._proof,
     $._number,
-    $._primitive_value_set
+    $._primitive_value_set,
+    $._number_set
   ],
 
   extras: $ => [
@@ -277,7 +278,7 @@ module.exports = grammar({
     // Can contain letters, numbers, and underscores
     // Must contain at least one alphabetic character (not number or _)
     // Cannot start with WF_ or SF_
-    identifier: $ => /([0-9_]*[A-Za-z][A-Za-z0-9_]*)|ℕ|ℤ|ℝ/,
+    identifier: $ => /([0-9_]*[A-Za-z][A-Za-z0-9_]*)/,
 
     // EXTENDS Naturals, FiniteSets, Sequences
     extends: $ => seq(
@@ -347,7 +348,7 @@ module.exports = grammar({
     // x ≜ 〈 1, 2, 3, 4, 5 〉
     operator_definition: $ => seq(
       choice(
-        arity0OrN($.identifier, $._id_or_op_declaration),
+        arity0OrN(choice($.identifier, $._number_set), $._id_or_op_declaration),
         seq(
           field('name', $.prefix_op_symbol),
           field('parameter', $.identifier)
@@ -532,7 +533,7 @@ module.exports = grammar({
     prefixed_op: $ => seq(
       field('prefix', $.subexpr_prefix),
       field('op', choice(
-        alias($.identifier, $.identifier_ref),
+        choice(alias($.identifier, $.identifier_ref), $._number_set),
         $.bound_op,
         $.bound_nonfix_op
       ))
@@ -586,11 +587,12 @@ module.exports = grammar({
     // TRUE, FALSE, BOOLEAN
     boolean: $ => choice('TRUE', 'FALSE'),
 
+    // Various number sets
+    _number_set: $ => choice($.nat_number_set, $.int_number_set, $.real_number_set),
+
     // Set of all strings, booleans, and numbers
-    _primitive_value_set: $ => choice(
-      $.string_set,     $.boolean_set,  $.nat_number_set,
-      $.int_number_set, $.real_number_set
-    ),
+    _primitive_value_set: $ => choice($.string_set, $.boolean_set, $._number_set),
+
     string_set:       $ => 'STRING',            // From TLA⁺ builtins
     boolean_set:      $ => 'BOOLEAN',           // From TLA⁺ builtins
     nat_number_set:   $ => choice('Nat', 'ℕ'),  // From Naturals standard module

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -774,7 +774,7 @@
     },
     "identifier": {
       "type": "PATTERN",
-      "value": "([0-9_]*[A-Za-z][A-Za-z0-9_]*)|ℕ|ℤ|ℝ"
+      "value": "([0-9_]*[A-Za-z][A-Za-z0-9_]*)"
     },
     "extends": {
       "type": "SEQ",
@@ -1160,8 +1160,17 @@
                   "type": "FIELD",
                   "name": "name",
                   "content": {
-                    "type": "SYMBOL",
-                    "name": "identifier"
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "identifier"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "_number_set"
+                      }
+                    ]
                   }
                 },
                 {
@@ -2170,13 +2179,22 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "ALIAS",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "identifier"
-                },
-                "named": true,
-                "value": "identifier_ref"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "identifier"
+                    },
+                    "named": true,
+                    "value": "identifier_ref"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_number_set"
+                  }
+                ]
               },
               {
                 "type": "SYMBOL",
@@ -2401,6 +2419,23 @@
         }
       ]
     },
+    "_number_set": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "nat_number_set"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "int_number_set"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "real_number_set"
+        }
+      ]
+    },
     "_primitive_value_set": {
       "type": "CHOICE",
       "members": [
@@ -2414,15 +2449,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "nat_number_set"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "int_number_set"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "real_number_set"
+          "name": "_number_set"
         }
       ]
     },
@@ -9683,6 +9710,7 @@
     "_op",
     "_proof",
     "_number",
-    "_primitive_value_set"
+    "_primitive_value_set",
+    "_number_set"
   ]
 }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -184,6 +184,24 @@
     ]
   },
   {
+    "type": "_number_set",
+    "named": true,
+    "subtypes": [
+      {
+        "type": "int_number_set",
+        "named": true
+      },
+      {
+        "type": "nat_number_set",
+        "named": true
+      },
+      {
+        "type": "real_number_set",
+        "named": true
+      }
+    ]
+  },
+  {
     "type": "_op",
     "named": true,
     "subtypes": [
@@ -210,19 +228,11 @@
     "named": true,
     "subtypes": [
       {
+        "type": "_number_set",
+        "named": true
+      },
+      {
         "type": "boolean_set",
-        "named": true
-      },
-      {
-        "type": "int_number_set",
-        "named": true
-      },
-      {
-        "type": "nat_number_set",
-        "named": true
-      },
-      {
-        "type": "real_number_set",
         "named": true
       },
       {
@@ -2674,6 +2684,10 @@
         "required": true,
         "types": [
           {
+            "type": "_number_set",
+            "named": true
+          },
+          {
             "type": "identifier",
             "named": true
           },
@@ -3823,6 +3837,10 @@
         "multiple": false,
         "required": true,
         "types": [
+          {
+            "type": "_number_set",
+            "named": true
+          },
           {
             "type": "bound_nonfix_op",
             "named": true

--- a/test/corpus/number.txt
+++ b/test/corpus/number.txt
@@ -44,3 +44,36 @@ op == Real
   (operator_definition name: (identifier) (def_eq) definition: (real_number_set))
 (double_line)))
 
+=============|||
+Number Set Definitions
+=============|||
+
+---- MODULE Test ----
+Nat == {}
+op == A!Nat
+Int == {}
+op == A!Int
+Real == {}
+op == A!Real
+====
+
+-------------|||
+
+(source_file (module (header_line) name: (identifier) (header_line)
+  (operator_definition name: (nat_number_set) (def_eq) definition: (finite_set_literal))
+  (operator_definition name: (identifier) (def_eq) definition: (prefixed_op
+    prefix: (subexpr_prefix (subexpr_component (identifier_ref)))
+    op: (nat_number_set)
+  ))
+  (operator_definition name: (int_number_set) (def_eq) definition: (finite_set_literal))
+  (operator_definition name: (identifier) (def_eq) definition: (prefixed_op
+    prefix: (subexpr_prefix (subexpr_component (identifier_ref)))
+    op: (int_number_set)
+  ))
+  (operator_definition name: (real_number_set) (def_eq) definition: (finite_set_literal))
+  (operator_definition name: (identifier) (def_eq) definition: (prefixed_op
+    prefix: (subexpr_prefix (subexpr_component (identifier_ref)))
+    op: (real_number_set)
+  ))
+(double_line)))
+

--- a/test/corpus/unicode/numbers-unicode.txt
+++ b/test/corpus/unicode/numbers-unicode.txt
@@ -4,15 +4,30 @@ Unicode Number Sets
 
 ---- MODULE Test ----
 ℕ ≜ {}
+op ≜ A!ℕ
 ℤ ≜ {}
+op ≜ A!ℤ
 ℝ ≜ {}
+op ≜ A!ℝ
 ====
 
 -------------|||
 
 (source_file (module (header_line) name: (identifier) (header_line)
-  (operator_definition name: (identifier) (def_eq) definition: (finite_set_literal))
-  (operator_definition name: (identifier) (def_eq) definition: (finite_set_literal))
-  (operator_definition name: (identifier) (def_eq) definition: (finite_set_literal))
+  (operator_definition name: (nat_number_set) (def_eq) definition: (finite_set_literal))
+  (operator_definition name: (identifier) (def_eq) definition: (prefixed_op
+    prefix: (subexpr_prefix (subexpr_component (identifier_ref)))
+    op: (nat_number_set)
+  ))
+  (operator_definition name: (int_number_set) (def_eq) definition: (finite_set_literal))
+  (operator_definition name: (identifier) (def_eq) definition: (prefixed_op
+    prefix: (subexpr_prefix (subexpr_component (identifier_ref)))
+    op: (int_number_set)
+  ))
+  (operator_definition name: (real_number_set) (def_eq) definition: (finite_set_literal))
+  (operator_definition name: (identifier) (def_eq) definition: (prefixed_op
+    prefix: (subexpr_prefix (subexpr_component (identifier_ref)))
+    op: (real_number_set)
+  ))
 (double_line)))
 


### PR DESCRIPTION
@will62794 as FYI, this is not likely to break any specs users are giving you yet but if users define Nat/Int/Real operators in their module (or their unicode equivalents) those will appear as `nat_number_set` etc. instead of just `identifier`. See test file modifications for examples. This is being done to aid Unicode translation by TLAUC, see https://github.com/tlaplus-community/tlauc/issues/11