### PR TITLE
Allow PlusCal algorithms as top-level parse entities

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -174,6 +174,7 @@ module.exports = grammar({
     // * a valid TLA⁺ source file with an encapsulating module
     // * a source file containing multiple modules (ambiguously valid but used by the tools)
     // * a TLA⁺ snippet without an encapsulating module
+    // * a PlusCal algorithm without an encapsulating module
     source_file: $ => choice(
       seq(
         optional(alias($.leading_extramodular_text, $.extramodular_text)),
@@ -182,7 +183,8 @@ module.exports = grammar({
       seq(
         optional($.extends),
         repeat($._unit)
-      )
+      ),
+      $.pcal_algorithm
     ),
 
     // \* this is a comment ending with newline

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -83,6 +83,10 @@
               }
             }
           ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "pcal_algorithm"
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -4249,6 +4249,10 @@
         {
           "type": "extramodular_text",
           "named": true
+        },
+        {
+          "type": "pcal_algorithm",
+          "named": true
         }
       ]
     }

--- a/test/corpus/pluscal/assert.txt
+++ b/test/corpus/pluscal/assert.txt
@@ -1,25 +1,18 @@
 ==================|||
 PlusCal Assert
 ==================|||
----- MODULE Test ----
-(* --algorithm Test
-begin
+
+--algorithm Test begin
   assert TRUE
-end algorithm *)
-====
+end algorithm
 
 -------------|||
 
 (source_file
-  (module
-    (header_line)
-    (identifier)
-    (header_line)
-    (block_comment
-      (pcal_algorithm
-        (pcal_algorithm_start)
-        (identifier)
-        (pcal_algorithm_body
-          (pcal_assert
-            (boolean)))))
-    (double_line)))
+  (pcal_algorithm (pcal_algorithm_start) name: (identifier)
+    (pcal_algorithm_body
+      (pcal_assert (boolean))
+    )
+  )
+)
+


### PR DESCRIPTION
This eases development of a unified parser test corpus, since we don't need to ensconce the PlusCal test cases in a module & block comment.