### PR TITLE
fix!: adapt to breaking upstream changes

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -239,8 +239,8 @@ module.exports = grammar({
     gets:               $ => choice('<-', '⟵', '←'),
     forall:             $ => choice('\\A', '\\forall', '∀'),
     exists:             $ => choice('\\E', '\\exists', '∃'),
-    temporal_forall:    $ => choice('\\AA'),
-    temporal_exists:    $ => choice('\\EE'),
+    temporal_forall:    $ => '\\AA',
+    temporal_exists:    $ => '\\EE',
     all_map_to:         $ => choice('|->', '⟼', '↦'),
     maps_to:            $ => choice('->', '⟶', '→'),
     langle_bracket:     $ => choice('<<', '〈', '⟨'),
@@ -1589,7 +1589,7 @@ module.exports = grammar({
 
     // Statement, that does nothing:
     // skip
-    pcal_skip: $ => seq('skip'),
+    pcal_skip: $ => 'skip',
 
     // Used in procedures. Assigns to the parameters and local
     // procedure variables their previous values
@@ -1598,7 +1598,7 @@ module.exports = grammar({
     //   a := b;
     //   return;
     // end procedure
-    pcal_return: $ => seq('return'),
+    pcal_return: $ => 'return',
 
     // Jump to a label:
     // process foo begin

--- a/integrations/nvim/queries/tlaplus/highlights.scm
+++ b/integrations/nvim/queries/tlaplus/highlights.scm
@@ -2,7 +2,6 @@
 ; ; Default capture names for nvim-treesitter found here:
 ; ; https://github.com/nvim-treesitter/nvim-treesitter/blob/e473630fe0872cb0ed97cd7085e724aa58bc1c84/lua/nvim-treesitter/highlight.lua#L14-L104
 ; ; In this file, captures defined later take precedence over captures defined earlier
-
 ; Keywords
 [
   "ACTION"
@@ -97,11 +96,15 @@
   "when"
   "with"
 ] @keyword
-[
-  "await"
-] @keyword.coroutine
-(pcal_with ("=") @keyword)
-(pcal_process ("=") @keyword)
+
+"await" @keyword.coroutine
+
+(pcal_with
+  "=" @keyword)
+
+(pcal_process
+  "=" @keyword)
+
 [
   "if"
   "then"
@@ -111,6 +114,7 @@
   "either"
   (pcal_end_either)
 ] @conditional
+
 [
   "while"
   "do"
@@ -118,75 +122,177 @@
   "with"
   (pcal_end_with)
 ] @repeat
-(pcal_return) @keyword.return
-("print") @function.macro
 
+(pcal_return) @keyword.return
+
+"print" @function.macro
 
 ; Literals
-(binary_number (format) @keyword)
-(binary_number (value) @number)
+(binary_number
+  (format) @keyword)
+
+(binary_number
+  (value) @number)
+
 (boolean) @boolean
+
 (boolean_set) @type
-(hex_number (format) @keyword)
-(hex_number (value) @number)
+
+(hex_number
+  (format) @keyword)
+
+(hex_number
+  (value) @number)
+
 (int_number_set) @type
+
 (nat_number) @number
+
 (nat_number_set) @type
-(octal_number (format) @keyword)
-(octal_number (value) @number)
+
+(octal_number
+  (format) @keyword)
+
+(octal_number
+  (value) @number)
+
 (real_number) @number
+
 (real_number_set) @type
+
 (string) @string
+
 (escape_char) @string.escape
+
 (string_set) @type
 
 ; Namespaces
-(extends (identifier_ref) @namespace)
-(instance (identifier_ref) @namespace)
-(module name: (identifier) @namespace)
-(pcal_algorithm name: (identifier) @namespace)
+(extends
+  (identifier_ref) @namespace)
+
+(instance
+  (identifier_ref) @namespace)
+
+(module
+  name: (identifier) @namespace)
+
+(pcal_algorithm
+  name: (identifier) @namespace)
 
 ; Operators, functions, and macros
-(bound_infix_op symbol: (_) @operator)
-(bound_nonfix_op symbol: (_) @operator)
-(bound_postfix_op symbol: (_) @operator)
-(bound_prefix_op symbol: (_) @operator)
-((prefix_op_symbol) @operator)
-((infix_op_symbol) @operator)
-((postfix_op_symbol) @operator)
-(function_definition name: (identifier) @function)
-(module_definition name: (_) @include)
-(operator_definition name: (_) @function.macro)
-(pcal_macro_decl name: (identifier) @function.macro)
-(pcal_macro_call name: (identifier) @function.macro)
-(pcal_proc_decl name: (identifier) @function.macro)
-(pcal_process name: (identifier) @function)
-(recursive_declaration (identifier) @function.macro)
-(recursive_declaration (operator_declaration name: (_) @function.macro))
+(bound_infix_op
+  symbol: (_) @operator)
+
+(bound_nonfix_op
+  symbol: (_) @operator)
+
+(bound_postfix_op
+  symbol: (_) @operator)
+
+(bound_prefix_op
+  symbol: (_) @operator)
+
+(prefix_op_symbol) @operator
+
+(infix_op_symbol) @operator
+
+(postfix_op_symbol) @operator
+
+(function_definition
+  name: (identifier) @function)
+
+(module_definition
+  name: (_) @include)
+
+(operator_definition
+  name: (_) @function.macro)
+
+(pcal_macro_decl
+  name: (identifier) @function.macro)
+
+(pcal_macro_call
+  name: (identifier) @function.macro)
+
+(pcal_proc_decl
+  name: (identifier) @function.macro)
+
+(pcal_process
+  name: (identifier) @function)
+
+(recursive_declaration
+  (identifier) @function.macro)
+
+(recursive_declaration
+  (operator_declaration
+    name: (_) @function.macro))
 
 ; Constants and variables
-(constant_declaration (identifier) @constant)
-(constant_declaration (operator_declaration name: (_) @constant))
-(pcal_var_decl (identifier) @variable)
-(pcal_with (identifier) @parameter)
-((".") . (identifier) @attribute)
-(record_literal (identifier) @attribute)
-(set_of_records (identifier) @attribute)
-(variable_declaration (identifier) @variable)
+(constant_declaration
+  (identifier) @constant)
+
+(constant_declaration
+  (operator_declaration
+    name: (_) @constant))
+
+(pcal_var_decl
+  (identifier) @variable)
+
+(pcal_with
+  (identifier) @parameter)
+
+("."
+  .
+  (identifier) @attribute)
+
+(record_literal
+  (identifier) @attribute)
+
+(set_of_records
+  (identifier) @attribute)
+
+(variable_declaration
+  (identifier) @variable)
 
 ; Parameters
-(choose (identifier) @parameter)
-(choose (tuple_of_identifiers (identifier) @parameter))
-(lambda (identifier) @parameter)
-(module_definition (operator_declaration name: (_) @parameter))
-(module_definition parameter: (identifier) @parameter)
-(operator_definition (operator_declaration name: (_) @parameter))
-(operator_definition parameter: (identifier) @parameter)
-(pcal_macro_decl parameter: (identifier) @parameter)
-(pcal_proc_var_decl (identifier) @parameter)
-(quantifier_bound (identifier) @parameter)
-(quantifier_bound (tuple_of_identifiers (identifier) @parameter))
-(unbounded_quantification (identifier) @parameter)
+(choose
+  (identifier) @parameter)
+
+(choose
+  (tuple_of_identifiers
+    (identifier) @parameter))
+
+(lambda
+  (identifier) @parameter)
+
+(module_definition
+  (operator_declaration
+    name: (_) @parameter))
+
+(module_definition
+  parameter: (identifier) @parameter)
+
+(operator_definition
+  (operator_declaration
+    name: (_) @parameter))
+
+(operator_definition
+  parameter: (identifier) @parameter)
+
+(pcal_macro_decl
+  parameter: (identifier) @parameter)
+
+(pcal_proc_var_decl
+  (identifier) @parameter)
+
+(quantifier_bound
+  (identifier) @parameter)
+
+(quantifier_bound
+  (tuple_of_identifiers
+    (identifier) @parameter))
+
+(unbounded_quantification
+  (identifier) @parameter)
 
 ; Delimiters
 [
@@ -201,6 +307,7 @@
   "("
   ")"
 ] @punctuation.bracket
+
 [
   ","
   ":"
@@ -214,57 +321,164 @@
 ] @punctuation.delimiter
 
 ; Proofs
-(assume_prove (new (identifier) @parameter))
-(assume_prove (new (operator_declaration name: (_) @parameter)))
-(assumption name: (identifier) @constant)
-(pick_proof_step (identifier) @parameter)
-(proof_step_id "<" @punctuation.bracket)
-(proof_step_id (level) @label)
-(proof_step_id (name) @label)
-(proof_step_id ">" @punctuation.bracket)
-(proof_step_ref "<" @punctuation.bracket)
-(proof_step_ref (level) @label)
-(proof_step_ref (name) @label)
-(proof_step_ref ">" @punctuation.bracket)
-(take_proof_step (identifier) @parameter)
-(theorem name: (identifier) @constant)
+(assume_prove
+  (new
+    (identifier) @parameter))
+
+(assume_prove
+  (new
+    (operator_declaration
+      name: (_) @parameter)))
+
+(assumption
+  name: (identifier) @constant)
+
+(pick_proof_step
+  (identifier) @parameter)
+
+(proof_step_id
+  "<" @punctuation.bracket)
+
+(proof_step_id
+  (level) @label)
+
+(proof_step_id
+  (name) @label)
+
+(proof_step_id
+  ">" @punctuation.bracket)
+
+(proof_step_ref
+  "<" @punctuation.bracket)
+
+(proof_step_ref
+  (level) @label)
+
+(proof_step_ref
+  (name) @label)
+
+(proof_step_ref
+  ">" @punctuation.bracket)
+
+(take_proof_step
+  (identifier) @parameter)
+
+(theorem
+  name: (identifier) @constant)
 
 ; Comments and tags
-(block_comment "(*" @comment)
-(block_comment "*)" @comment)
+(block_comment
+  "(*" @comment)
+
+(block_comment
+  "*)" @comment)
+
 (block_comment_text) @comment
+
 (comment) @comment
+
 (single_line) @comment
-(_ label: (identifier) @label)
-(label name: (_) @label)
-(pcal_goto statement: (identifier) @label)
+
+(_
+  label: (identifier) @label)
+
+(label
+  name: (_) @label)
+
+(pcal_goto
+  statement: (identifier) @label)
 
 ; Reference highlighting with the same color as declarations.
 ; `constant`, `operator`, and others are custom captures defined in locals.scm
-((identifier_ref) @constant (#is? @constant constant))
-((identifier_ref) @function (#is? @function function))
-((identifier_ref) @function.macro (#is? @function.macro macro))
-((identifier_ref) @include (#is? @include import))
-((identifier_ref) @parameter (#is? @parameter parameter))
-((identifier_ref) @variable (#is? @variable var))
-((prefix_op_symbol) @constant (#is? @constant constant))
-((prefix_op_symbol) @function.macro (#is? @function.macro macro))
-((prefix_op_symbol) @parameter (#is? @parameter parameter))
-((infix_op_symbol) @constant (#is? @constant constant))
-((infix_op_symbol) @function.macro (#is? @function.macro macro))
-((infix_op_symbol) @parameter (#is? @parameter parameter))
-((postfix_op_symbol) @constant (#is? @constant constant))
-((postfix_op_symbol) @function.macro (#is? @function.macro macro))
-((postfix_op_symbol) @parameter (#is? @parameter parameter))
-(bound_prefix_op symbol: (_) @constant (#is? @constant constant))
-(bound_prefix_op symbol: (_) @function.macro (#is? @function.macro macro))
-(bound_prefix_op symbol: (_) @parameter (#is? @parameter parameter))
-(bound_infix_op symbol: (_) @constant (#is? @constant constant))
-(bound_infix_op symbol: (_) @function.macro (#is? @function.macro macro))
-(bound_infix_op symbol: (_) @parameter (#is? @parameter parameter))
-(bound_postfix_op symbol: (_) @constant (#is? @constant constant))
-(bound_postfix_op symbol: (_) @function.macro (#is? @function.macro macro))
-(bound_postfix_op symbol: (_) @parameter (#is? @parameter parameter))
-(bound_nonfix_op symbol: (_) @constant (#is? @constant constant))
-(bound_nonfix_op symbol: (_) @function.macro (#is? @function.macro macro))
-(bound_nonfix_op symbol: (_) @parameter (#is? @parameter parameter))
+((identifier_ref) @constant
+  (#is? @constant constant))
+
+((identifier_ref) @function
+  (#is? @function function))
+
+((identifier_ref) @function.macro
+  (#is? @function.macro macro))
+
+((identifier_ref) @include
+  (#is? @include import))
+
+((identifier_ref) @parameter
+  (#is? @parameter parameter))
+
+((identifier_ref) @variable
+  (#is? @variable var))
+
+((prefix_op_symbol) @constant
+  (#is? @constant constant))
+
+((prefix_op_symbol) @function.macro
+  (#is? @function.macro macro))
+
+((prefix_op_symbol) @parameter
+  (#is? @parameter parameter))
+
+((infix_op_symbol) @constant
+  (#is? @constant constant))
+
+((infix_op_symbol) @function.macro
+  (#is? @function.macro macro))
+
+((infix_op_symbol) @parameter
+  (#is? @parameter parameter))
+
+((postfix_op_symbol) @constant
+  (#is? @constant constant))
+
+((postfix_op_symbol) @function.macro
+  (#is? @function.macro macro))
+
+((postfix_op_symbol) @parameter
+  (#is? @parameter parameter))
+
+(bound_prefix_op
+  symbol: (_) @constant
+  (#is? @constant constant))
+
+(bound_prefix_op
+  symbol: (_) @function.macro
+  (#is? @function.macro macro))
+
+(bound_prefix_op
+  symbol: (_) @parameter
+  (#is? @parameter parameter))
+
+(bound_infix_op
+  symbol: (_) @constant
+  (#is? @constant constant))
+
+(bound_infix_op
+  symbol: (_) @function.macro
+  (#is? @function.macro macro))
+
+(bound_infix_op
+  symbol: (_) @parameter
+  (#is? @parameter parameter))
+
+(bound_postfix_op
+  symbol: (_) @constant
+  (#is? @constant constant))
+
+(bound_postfix_op
+  symbol: (_) @function.macro
+  (#is? @function.macro macro))
+
+(bound_postfix_op
+  symbol: (_) @parameter
+  (#is? @parameter parameter))
+
+(bound_nonfix_op
+  symbol: (_) @constant
+  (#is? @constant constant))
+
+(bound_nonfix_op
+  symbol: (_) @function.macro
+  (#is? @function.macro macro))
+
+(bound_nonfix_op
+  symbol: (_) @parameter
+  (#is? @parameter parameter))

--- a/integrations/nvim/queries/tlaplus/highlights.scm
+++ b/integrations/nvim/queries/tlaplus/highlights.scm
@@ -1,4 +1,4 @@
-; ; Intended for consumption by nvim-treesitter 
+; ; Intended for consumption by nvim-treesitter
 ; ; Default capture names for nvim-treesitter found here:
 ; ; https://github.com/nvim-treesitter/nvim-treesitter/blob/e473630fe0872cb0ed97cd7085e724aa58bc1c84/lua/nvim-treesitter/highlight.lua#L14-L104
 ; ; In this file, captures defined later take precedence over captures defined earlier
@@ -91,7 +91,7 @@
   "or"
   "procedure"
   "process"
-  "skip"
+  (pcal_skip)
   "variable"
   "variables"
   "when"
@@ -102,23 +102,23 @@
 ] @keyword.coroutine
 (pcal_with ("=") @keyword)
 (pcal_process ("=") @keyword)
-[ 
-  "if" 
-  "then" 
-  "else" 
+[
+  "if"
+  "then"
+  "else"
   "elsif"
   (pcal_end_if)
   "either"
   (pcal_end_either)
 ] @conditional
-[ 
-  "while" 
-  "do" 
-  (pcal_end_while) 
-  "with" 
+[
+  "while"
+  "do"
+  (pcal_end_while)
+  "with"
   (pcal_end_with)
 ] @repeat
-("return") @keyword.return
+(pcal_return) @keyword.return
 ("print") @function.macro
 
 

--- a/integrations/nvim/queries/tlaplus/locals.scm
+++ b/integrations/nvim/queries/tlaplus/locals.scm
@@ -2,11 +2,11 @@
 [
   (bounded_quantification)
   (choose)
-  (function_definition) 
+  (function_definition)
   (function_literal)
-  (lambda) 
+  (lambda)
   (let_in)
-  (module) 
+  (module)
   (module_definition)
   (operator_definition)
   (set_filter)
@@ -14,28 +14,61 @@
   (unbounded_quantification)
 ] @scope
 
-(choose (identifier) @definition.parameter)
-(choose (tuple_of_identifiers (identifier) @definition.parameter))
-(constant_declaration (identifier) @definition.constant)
-(constant_declaration (operator_declaration name: (_) @definition.constant))
+(choose
+  (identifier) @definition.parameter)
+
+(choose
+  (tuple_of_identifiers
+    (identifier) @definition.parameter))
+
+(constant_declaration
+  (identifier) @definition.constant)
+
+(constant_declaration
+  (operator_declaration
+    name: (_) @definition.constant))
+
 (function_definition
   name: (identifier) @definition.function
   (#set! "definition.function.scope" "parent"))
-(lambda (identifier) @definition.parameter)
+
+(lambda
+  (identifier) @definition.parameter)
+
 (module_definition
   name: (_) @definition.import
   (#set! "definition.import.scope" "parent"))
-(module_definition parameter: (identifier) @definition.parameter)
-(module_definition parameter: (operator_declaration name: (_) @definition.parameter))
+
+(module_definition
+  parameter: (identifier) @definition.parameter)
+
+(module_definition
+  parameter: (operator_declaration
+    name: (_) @definition.parameter))
+
 (operator_definition
   name: (_) @definition.macro
   (#set! "definition.macro.scope" "parent"))
-(operator_definition parameter: (identifier) @definition.parameter)
-(operator_definition parameter: (operator_declaration name: (_) @definition.parameter))
-(quantifier_bound (identifier) @definition.parameter)
-(quantifier_bound (tuple_of_identifiers (identifier) @definition.parameter))
-(unbounded_quantification (identifier) @definition.parameter)
-(variable_declaration (identifier) @definition.var)
+
+(operator_definition
+  parameter: (identifier) @definition.parameter)
+
+(operator_definition
+  parameter: (operator_declaration
+    name: (_) @definition.parameter))
+
+(quantifier_bound
+  (identifier) @definition.parameter)
+
+(quantifier_bound
+  (tuple_of_identifiers
+    (identifier) @definition.parameter))
+
+(unbounded_quantification
+  (identifier) @definition.parameter)
+
+(variable_declaration
+  (identifier) @definition.var)
 
 ; Proof scopes and definitions
 [
@@ -44,11 +77,24 @@
   (theorem)
 ] @scope
 
-(assume_prove (new (identifier) @definition.parameter))
-(assume_prove (new (operator_declaration name: (_) @definition.parameter)))
-(assumption name: (identifier) @definition.constant)
-(pick_proof_step (identifier) @definition.parameter)
-(take_proof_step (identifier) @definition.parameter)
+(assume_prove
+  (new
+    (identifier) @definition.parameter))
+
+(assume_prove
+  (new
+    (operator_declaration
+      name: (_) @definition.parameter)))
+
+(assumption
+  name: (identifier) @definition.constant)
+
+(pick_proof_step
+  (identifier) @definition.parameter)
+
+(take_proof_step
+  (identifier) @definition.parameter)
+
 (theorem
   name: (identifier) @definition.constant
   (#set! "definition.constant.scope" "parent"))
@@ -61,29 +107,61 @@
   (pcal_with)
 ] @scope
 
-(pcal_macro_decl parameter: (identifier) @definition.parameter)
-(pcal_proc_var_decl (identifier) @definition.parameter)
-(pcal_var_decl (identifier) @definition.var)
-(pcal_with (identifier) @definition.parameter)
+(pcal_macro_decl
+  parameter: (identifier) @definition.parameter)
+
+(pcal_proc_var_decl
+  (identifier) @definition.parameter)
+
+(pcal_var_decl
+  (identifier) @definition.var)
+
+(pcal_with
+  (identifier) @definition.parameter)
 
 ; Built-in PlusCal variables
 (pcal_algorithm_body
   [
-    (_ (identifier_ref) @definition.var)
-    (_ (_ (identifier_ref) @definition.var))
-    (_ (_ (_ (identifier_ref) @definition.var))) 
-    (_ (_ (_ (_ (identifier_ref) @definition.var))))
-    (_ (_ (_ (_ (_ (identifier_ref) @definition.var)))))
+    (_
+      (identifier_ref) @definition.var)
+    (_
+      (_
+        (identifier_ref) @definition.var))
+    (_
+      (_
+        (_
+          (identifier_ref) @definition.var)))
+    (_
+      (_
+        (_
+          (_
+            (identifier_ref) @definition.var))))
+    (_
+      (_
+        (_
+          (_
+            (_
+              (identifier_ref) @definition.var)))))
   ]
-  (#vim-match? @definition.var "^(self|pc|stack)$")
-)
+  (#vim-match? @definition.var "^(self|pc|stack)$"))
 
 ; References
 (identifier_ref) @reference
-((prefix_op_symbol) @reference)
-(bound_prefix_op symbol: (_) @reference)
-((infix_op_symbol) @reference)
-(bound_infix_op symbol: (_) @reference)
-((postfix_op_symbol) @reference)
-(bound_postfix_op symbol: (_) @reference)
-(bound_nonfix_op symbol: (_) @reference)
+
+(prefix_op_symbol) @reference
+
+(bound_prefix_op
+  symbol: (_) @reference)
+
+(infix_op_symbol) @reference
+
+(bound_infix_op
+  symbol: (_) @reference)
+
+(postfix_op_symbol) @reference
+
+(bound_postfix_op
+  symbol: (_) @reference)
+
+(bound_nonfix_op
+  symbol: (_) @reference)

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -85,27 +85,27 @@
   "call"
   "define"
   "either"
-  "else" 
+  "else"
   "elsif"
   "end"
   "fair"
   "goto"
-  "if" 
+  "if"
   "macro"
   "or"
   "print"
   "procedure"
   "process"
-  "return"
-  "skip"
   "variable"
   "variables"
   "when"
   "with"
-  "then" 
+  "then"
   (pcal_algorithm_start)
   (pcal_end_either)
   (pcal_end_if)
+  (pcal_return)
+  (pcal_skip)
   (pcal_process ("="))
   (pcal_with ("="))
 ] @keyword

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -368,22 +368,12 @@
       ]
     },
     "temporal_forall": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "\\AA"
-        }
-      ]
+      "type": "STRING",
+      "value": "\\AA"
     },
     "temporal_exists": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "\\EE"
-        }
-      ]
+      "type": "STRING",
+      "value": "\\EE"
     },
     "all_map_to": {
       "type": "CHOICE",
@@ -9338,22 +9328,12 @@
       ]
     },
     "pcal_skip": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "skip"
-        }
-      ]
+      "type": "STRING",
+      "value": "skip"
     },
     "pcal_return": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "return"
-        }
-      ]
+      "type": "STRING",
+      "value": "return"
     },
     "pcal_goto": {
       "type": "SEQ",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3468,16 +3468,6 @@
     }
   },
   {
-    "type": "pcal_return",
-    "named": true,
-    "fields": {}
-  },
-  {
-    "type": "pcal_skip",
-    "named": true,
-    "fields": {}
-  },
-  {
     "type": "pcal_var_decl",
     "named": true,
     "fields": {},
@@ -4563,16 +4553,6 @@
     }
   },
   {
-    "type": "temporal_exists",
-    "named": true,
-    "fields": {}
-  },
-  {
-    "type": "temporal_forall",
-    "named": true,
-    "fields": {}
-  },
-  {
     "type": "terminal_proof",
     "named": true,
     "fields": {},
@@ -5328,15 +5308,7 @@
     "named": false
   },
   {
-    "type": "\\AA",
-    "named": false
-  },
-  {
     "type": "\\E",
-    "named": false
-  },
-  {
-    "type": "\\EE",
     "named": false
   },
   {
@@ -5744,6 +5716,14 @@
     "named": true
   },
   {
+    "type": "pcal_return",
+    "named": true
+  },
+  {
+    "type": "pcal_skip",
+    "named": true
+  },
+  {
     "type": "placeholder",
     "named": true
   },
@@ -5780,16 +5760,8 @@
     "named": true
   },
   {
-    "type": "return",
-    "named": false
-  },
-  {
     "type": "setminus",
     "named": true
-  },
-  {
-    "type": "skip",
-    "named": false
   },
   {
     "type": "slash",
@@ -5805,6 +5777,14 @@
   },
   {
     "type": "sup_hash",
+    "named": true
+  },
+  {
+    "type": "temporal_exists",
+    "named": true
+  },
+  {
+    "type": "temporal_forall",
     "named": true
   },
   {


### PR DESCRIPTION
Problem: The "trick" of wrapping an anonymous node into a single `choice` or `seq` no longer works as of https://github.com/tree-sitter/tree-sitter/pull/2577  since the wrapped anonymous nodes are no longer exposed to queries.

Solution: Drop unnecessary `choice` and `skip` and use named nodes in queries instead (anonymous nodes are no longer exposed).

@amaanq