### PR TITLE
Bump tree-sitter Rust dependency to 0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,10 @@ include = ["bindings/rust/*", "grammar.js", "queries/*", "src/*"]
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "0.22.5"
+tree-sitter-language = "0.1.0"
+
+[dev-dependencies]
+tree-sitter = "0.23"
 
 [build-dependencies]
 cc = "1.0.87"

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -4,10 +4,22 @@
 //! tree-sitter [Parser][], and then use the parser to parse some code:
 //!
 //! ```
+//! use tree_sitter::Parser;
+//!
 //! let code = r#"
+//! VARIABLE clock
+//!
+//! Init == clock \in {0, 1}
+//!
+//! Tick == IF clock = 0 THEN clock' = 1 ELSE clock' = 0
+//!
+//! Spec == Init /\ [][Tick]_<<clock>>
 //! "#;
-//! let mut parser = tree_sitter::Parser::new();
-//! parser.set_language(&tree_sitter_tlaplus::language()).expect("Error loading Tlaplus grammar");
+//! let mut parser = Parser::new();
+//! let language = tree_sitter_tlaplus::LANGUAGE;
+//! parser
+//!     .set_language(&language.into())
+//!     .expect("Error loading Tlaplus parser");
 //! let tree = parser.parse(code, None).unwrap();
 //! assert!(!tree.root_node().has_error());
 //! ```
@@ -17,30 +29,28 @@
 //! [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
 //! [tree-sitter]: https://tree-sitter.github.io/
 
-use tree_sitter::Language;
+use tree_sitter_language::LanguageFn;
 
 extern "C" {
-    fn tree_sitter_tlaplus() -> Language;
+    fn tree_sitter_tlaplus() -> *const ();
 }
 
-/// Get the tree-sitter [Language][] for this grammar.
-///
-/// [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
-pub fn language() -> Language {
-    unsafe { tree_sitter_tlaplus() }
-}
+/// The tree-sitter [`LanguageFn`] for this grammar.
+pub const LANGUAGE: LanguageFn = unsafe { LanguageFn::from_raw(tree_sitter_tlaplus) };
 
 /// The content of the [`node-types.json`][] file for this grammar.
 ///
 /// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types
-pub const NODE_TYPES: &str = include_str!("../../src/node-types.json");
+pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
 
-// Uncomment these to include any queries that this grammar contains
+/// The syntax highlighting query for this language.
+pub const HIGHLIGHT_QUERY: &'static str = include_str!("../../queries/highlights.scm");
 
-pub const HIGHLIGHTS_QUERY: &str = include_str!("../../queries/highlights.scm");
-// pub const INJECTIONS_QUERY: &str = include_str!("../../queries/injections.scm");
-pub const LOCALS_QUERY: &str = include_str!("../../queries/locals.scm");
-// pub const TAGS_QUERY: &str = include_str!("../../queries/tags.scm");
+// The locals tagging query for this language.
+pub const LOCALS_QUERY: &'static str = include_str!("../../queries/locals.scm");
+
+/// The symbol tagging query for this language.
+// pub const TAGS_QUERY: &'static str = include_str!("../../queries/tags.scm");
 
 #[cfg(test)]
 mod tests {
@@ -48,7 +58,7 @@ mod tests {
     fn test_can_load_grammar() {
         let mut parser = tree_sitter::Parser::new();
         parser
-            .set_language(&super::language())
-            .expect("Error loading Tlaplus grammar");
+            .set_language(&super::LANGUAGE.into())
+            .expect("Error loading Tlaplus parser");
     }
 }

--- a/test/consumers/rust/Cargo.toml
+++ b/test/consumers/rust/Cargo.toml
@@ -5,5 +5,6 @@ edition = "2021"
 
 [dependencies]
 tree-sitter-tlaplus = {path = "../../.."}
-tree-sitter = "0.22.5"
+tree-sitter-language = "0.1.0"
+tree-sitter = "0.23"
 

--- a/test/consumers/rust/src/main.rs
+++ b/test/consumers/rust/src/main.rs
@@ -2,7 +2,9 @@ use tree_sitter::{Parser, Query, QueryCursor};
 
 fn main() {
     let mut parser = Parser::new();
-    parser.set_language(&tree_sitter_tlaplus::language()).expect("Error loading TLA+ grammar");
+    parser
+        .set_language(&tree_sitter_tlaplus::LANGUAGE.into())
+        .expect("Error loading TLA+ grammar");
     let source_code = r#"
         ---- MODULE Test ----
         op ≜ ∀ n ∈ ℕ : n ≥ 0
@@ -10,10 +12,13 @@ fn main() {
     let tree = parser.parse(source_code, None).unwrap();
     println!("{}", tree.root_node().to_sexp());
 
-    let query = Query::new(&tree_sitter_tlaplus::language(), "(def_eq \"≜\") @capture").unwrap();
+    let query = Query::new(
+        &tree_sitter_tlaplus::LANGUAGE.into(),
+        "(def_eq \"≜\") @capture",
+    )
+    .unwrap();
     let mut cursor = QueryCursor::new();
     for capture in cursor.matches(&query, tree.root_node(), "".as_bytes()) {
         println!("{:?}", capture);
     }
 }
-


### PR DESCRIPTION
This PR updates the tree-sitter version to 0.23 and makes corresponding changes to the rust bindings to make them uniform with current most up to date grammars for languages like C and C++.

The new lib.rs attempts to reproduce the behavior of @amaanq's corresponding changes elsewhere.

I'm not sure if the changes to Rust alone are sufficient given that there are a lot more bindings in place, but if so, then this should be good to go. 🤞 