### PR TITLE
Update tree-sitter.json

### DIFF
--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -1,8 +1,8 @@
 {
   "grammars": [
     {
-      "name": "@tlaplus/tlaplus",
-      "camelcase": "TlaplusTlaplus",
+      "name": "tlaplus",
+      "camelcase": "TLAplus",
       "scope": "source.tlaplus",
       "path": ".",
       "file-types": [


### PR DESCRIPTION
Remove npm-style scope from tree-sitter grammar name.

Fixes oddity noted in #137.