### PR TITLE
scanner: remove erroneous array_delete on const parameter

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -284,7 +284,6 @@
           }
         }
       }
-      array_delete(raw_level);
       return id;
     }
 


### PR DESCRIPTION
Ref: https://github.com/tree-sitter/tree-sitter/actions/runs/21795611628/job/62882578559?pr=5309#step:10:252

The old `array_delete` macro silently stripped the const qualifier, but the change in https://github.com/tree-sitter/tree-sitter/pull/5309 expands the macro to also set the contents to `NULL`, which the compiler rejects. Also, the caller already calls `array_delete` after `parse_proof_step_id` returns, so this was technically a double-free with no side effects as the contents were already set to `NULL`.